### PR TITLE
DSP + Filter optimization updates

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.10.8"
 manifest_format = "2.0"
-project_hash = "5a21d9e848160985f2e47400066987ff2cb436f9"
+project_hash = "026f2260a0851e341de3d09419d48e6c1c416a12"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "e1ce448a0d7f88168ffe2eeac4549c32d45a42d1"
@@ -358,9 +358,9 @@ version = "3.1.0"
 
 [[deps.ClusterManagers]]
 deps = ["Distributed", "Logging", "Pkg", "Sockets"]
-git-tree-sha1 = "6a678b98d5ea4d2773e92c7ae607cf7371043684"
+git-tree-sha1 = "91d2b9e428bb96cdbbee8a7bef6b1936a3ebe8e7"
 uuid = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
-version = "0.4.6"
+version = "0.4.9"
 
 [[deps.Clustering]]
 deps = ["Distances", "LinearAlgebra", "NearestNeighbors", "Printf", "Random", "SparseArrays", "Statistics", "StatsBase"]
@@ -876,10 +876,10 @@ uuid = "77dc65aa-8811-40c2-897b-53d922fa7daf"
 version = "0.1.3"
 
 [[deps.Functors]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "64d8e93700c7a3f28f717d265382d52fac9fa1c1"
+deps = ["Compat", "ConstructionBase", "LinearAlgebra", "Random"]
+git-tree-sha1 = "60a0339f28a233601cb74468032b5c302d5067de"
 uuid = "d9f16b24-f501-4c13-a1f2-28368ffc5196"
-version = "0.4.12"
+version = "0.5.2"
 
 [[deps.Future]]
 deps = ["Random"]
@@ -1203,9 +1203,9 @@ version = "1.4.0"
 
 [[deps.Latexify]]
 deps = ["Format", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "OrderedCollections", "Requires"]
-git-tree-sha1 = "ce5f5621cac23a86011836badfedf664a612cee4"
+git-tree-sha1 = "cd714447457c660382fe634710fb56eb255ee42e"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-version = "0.16.5"
+version = "0.16.6"
 
     [deps.Latexify.extensions]
     DataFramesExt = "DataFrames"
@@ -1229,13 +1229,15 @@ version = "0.2.0"
 
 [[deps.LegendDSP]]
 deps = ["Adapt", "ArgCheck", "ArraysOfArrays", "DocStringExtensions", "FillArrays", "FunctionChains", "IntervalSets", "LIBSVM", "LegendDataTypes", "LinearAlgebra", "PropDicts", "RadiationDetectorDSP", "RadiationDetectorSignals", "Random", "Tables", "TypedTables", "Unitful"]
-path = "/home/iwsatlas1/henkes/.julia/dev/LegendDSP"
+git-tree-sha1 = "d4d945686861ebbeaceb26b4e8e1632c1b99c321"
+repo-rev = "patch_flt-opt"
+repo-url = "https://github.com/legend-exp/LegendDSP.jl.git"
 uuid = "e6d7a502-be5c-5049-a927-8d60e566555d"
 version = "0.2.3"
 
 [[deps.LegendDataManagement]]
 deps = ["Dates", "Distributed", "Format", "Glob", "IntervalSets", "JSON", "LRUCache", "LinearAlgebra", "MIMEs", "Markdown", "Measurements", "OhMyThreads", "Pkg", "Printf", "ProgressMeter", "PropDicts", "PropertyDicts", "PropertyFunctions", "StaticStrings", "Statistics", "StructArrays", "Tables", "TypedTables", "UUIDs", "Unitful", "UnitfulAtomic"]
-git-tree-sha1 = "fcecee0d994e4f8079ffc1d19d6984a7f96ec5cf"
+git-tree-sha1 = "5d36e2393a5934d4f5e7f77ea4a78854d86d7e57"
 repo-rev = "main"
 repo-url = "https://github.com/legend-exp/LegendDataManagement.jl.git"
 uuid = "9feedd95-f0e0-423f-a8dc-de0970eae6b3"
@@ -1279,7 +1281,9 @@ weakdeps = ["Measurements"]
 
 [[deps.LegendSpecFits]]
 deps = ["ArgCheck", "ArraysOfArrays", "BAT", "ChangesOfVariables", "DensityInterface", "Distributions", "FillArrays", "Format", "ForwardDiff", "GaussianMixtures", "IntervalSets", "InverseFunctions", "IrrationalConstants", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "LinearRegression", "LogExpFunctions", "LsqFit", "Measurements", "Measures", "Optim", "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "PropDicts", "RadiationSpectra", "Random", "Roots", "SnoopPrecompile", "SpecialFunctions", "Statistics", "StatsBase", "StructArrays", "Tables", "TypedTables", "Unitful", "ValueShapes"]
-path = "/home/iwsatlas1/henkes/.julia/dev/LegendSpecFits"
+git-tree-sha1 = "50491720e4ffd2de2d41bce2a0a0697f90d0ae2c"
+repo-rev = "patch_flt-opt"
+repo-url = "https://github.com/legend-exp/LegendSpecFits.jl.git"
 uuid = "18221496-77af-46cf-bab8-820da09f7f97"
 version = "0.3.0"
 weakdeps = ["Plots", "RecipesBase"]
@@ -1416,9 +1420,9 @@ uuid = "2fda8390-95c7-5789-9bda-21331edee243"
 version = "0.15.0"
 
 [[deps.MIMEs]]
-git-tree-sha1 = "1833212fd6f580c20d4291da9c1b4e8a655b128e"
+git-tree-sha1 = "65f28ad4b594aebe22157d6fac869786a255b7eb"
 uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
-version = "1.0.0"
+version = "0.1.4"
 
 [[deps.MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "oneTBB_jll"]
@@ -1481,14 +1485,15 @@ uuid = "fa1605e6-acd5-459c-a1e6-7e635759db14"
 version = "0.14.12"
 
 [[deps.Measurements]]
-deps = ["Calculus", "LinearAlgebra", "Printf", "Requires"]
-git-tree-sha1 = "bdcde8ec04ca84aef5b124a17684bf3b302de00e"
+deps = ["Calculus", "LinearAlgebra", "Printf"]
+git-tree-sha1 = "3019b28107f63ee881f5883da916dd9b6aa294c1"
 uuid = "eff96d63-e80a-5855-80a2-b1b0885c5ab7"
-version = "2.11.0"
+version = "2.12.0"
 
     [deps.Measurements.extensions]
     MeasurementsBaseTypeExt = "BaseType"
     MeasurementsJunoExt = "Juno"
+    MeasurementsMakieExt = "Makie"
     MeasurementsRecipesBaseExt = "RecipesBase"
     MeasurementsSpecialFunctionsExt = "SpecialFunctions"
     MeasurementsUnitfulExt = "Unitful"
@@ -1496,6 +1501,7 @@ version = "2.11.0"
     [deps.Measurements.weakdeps]
     BaseType = "7fbed51b-1ef5-4d67-9085-a4a9b26f478c"
     Juno = "e5e0dc1b-0480-54bc-9374-aad01c23163d"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
     RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
     SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
     Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
@@ -1544,9 +1550,9 @@ version = "7.8.3"
 
 [[deps.NLopt]]
 deps = ["CEnum", "NLopt_jll"]
-git-tree-sha1 = "dd79cb2a2d779209e42d76795edfde1c778eb5e0"
+git-tree-sha1 = "ddb22a00a2dd27c98e0a94879544eb92d192184a"
 uuid = "76087f3c-5699-56af-9a33-bf431cd00edd"
-version = "1.1.2"
+version = "1.1.3"
 
     [deps.NLopt.extensions]
     NLoptMathOptInterfaceExt = ["MathOptInterface"]
@@ -1556,9 +1562,9 @@ version = "1.1.2"
 
 [[deps.NLopt_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
-git-tree-sha1 = "dd645a206cc1e8bc4ff0dcfe3da08e39b60dd662"
+git-tree-sha1 = "b0154a615d5b2b6cf7a2501123b793577d0b9950"
 uuid = "079eb43e-fd8e-5478-9966-2cf3e3edb778"
-version = "2.9.0+0"
+version = "2.10.0+0"
 
 [[deps.NaNMath]]
 deps = ["OpenLibm_jll"]
@@ -1869,10 +1875,14 @@ uuid = "92933f4c-e287-5a05-a399-4b506db050ca"
 version = "1.10.2"
 
 [[deps.PropDicts]]
-deps = ["Functors", "JSON"]
-git-tree-sha1 = "7677e3a034868d66de3da7c45395475e03a0e93c"
+deps = ["JSON"]
+git-tree-sha1 = "05c688c5e867f57a7ed2ebf9d3ccbd995786481e"
 uuid = "4dc08600-4268-439e-8673-d706fafbb426"
-version = "0.2.5"
+version = "0.2.7"
+weakdeps = ["Functors"]
+
+    [deps.PropDicts.extensions]
+    PropDictsFunctorsExt = "Functors"
 
 [[deps.PropertyDicts]]
 git-tree-sha1 = "a6b4c12d38387a4382fa53b8a6591f9c219add16"
@@ -1916,9 +1926,9 @@ version = "6.7.1+1"
 
 [[deps.QuadGK]]
 deps = ["DataStructures", "LinearAlgebra"]
-git-tree-sha1 = "cda3b045cf9ef07a08ad46731f5a3165e56cf3da"
+git-tree-sha1 = "9da16da70037ba9d701192e27befedefb91ec284"
 uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
-version = "2.11.1"
+version = "2.11.2"
 
     [deps.QuadGK.extensions]
     QuadGKEnzymeExt = "Enzyme"
@@ -2008,9 +2018,9 @@ version = "0.6.12"
 
 [[deps.RecursiveArrayTools]]
 deps = ["Adapt", "ArrayInterface", "DocStringExtensions", "GPUArraysCore", "IteratorInterfaceExtensions", "LinearAlgebra", "RecipesBase", "StaticArraysCore", "Statistics", "SymbolicIndexingInterface", "Tables"]
-git-tree-sha1 = "ea6ad53c168c7c1c2e8f870aefda269692a8a91f"
+git-tree-sha1 = "fe9d37a17ab4d41a98951332ee8067f8dca8c4c2"
 uuid = "731186ca-8d62-57ce-b412-fbd966d074cd"
-version = "3.28.0"
+version = "3.29.0"
 
     [deps.RecursiveArrayTools.extensions]
     RecursiveArrayToolsFastBroadcastExt = "FastBroadcast"
@@ -2211,9 +2221,9 @@ version = "1.10.0"
 
 [[deps.SparseConnectivityTracer]]
 deps = ["ADTypes", "DocStringExtensions", "FillArrays", "LinearAlgebra", "Random", "SparseArrays"]
-git-tree-sha1 = "f6d636dcf886cf498b3bc484f48c37741d8aac6e"
+git-tree-sha1 = "970a24559004d9c2a3f8edbcb78eb416007c8616"
 uuid = "9f842d2f-2579-4b1d-911e-f412cf18a3f5"
-version = "0.6.10"
+version = "0.6.11"
 
     [deps.SparseConnectivityTracer.extensions]
     SparseConnectivityTracerDataInterpolationsExt = "DataInterpolations"
@@ -2474,9 +2484,9 @@ version = "0.4.1"
 
 [[deps.Unitful]]
 deps = ["Dates", "LinearAlgebra", "Random"]
-git-tree-sha1 = "01915bfcd62be15329c9a07235447a89d588327c"
+git-tree-sha1 = "c0667a8e676c53d390a09dc6870b3d8d6650e2bf"
 uuid = "1986cc42-f94f-5a68-af5c-568840ba703d"
-version = "1.21.1"
+version = "1.22.0"
 weakdeps = ["ConstructionBase", "InverseFunctions"]
 
     [deps.Unitful.extensions]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -126,9 +126,7 @@ version = "3.5.1+1"
 [[deps.ArrayInterface]]
 deps = ["Adapt", "LinearAlgebra"]
 git-tree-sha1 = "017fcb757f8e921fb44ee063a7aafe5f89b86dd1"
-git-tree-sha1 = "017fcb757f8e921fb44ee063a7aafe5f89b86dd1"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "7.18.0"
 version = "7.18.0"
 
     [deps.ArrayInterface.extensions]
@@ -468,9 +466,7 @@ version = "0.1.1"
 [[deps.ConcurrentUtilities]]
 deps = ["Serialization", "Sockets"]
 git-tree-sha1 = "f36e5e8fdffcb5646ea5da81495a5a7566005127"
-git-tree-sha1 = "f36e5e8fdffcb5646ea5da81495a5a7566005127"
 uuid = "f0e56b4a-5159-44fe-b623-3e5288b988bb"
-version = "2.4.3"
 version = "2.4.3"
 
 [[deps.ConsoleProgressMonitor]]
@@ -847,9 +843,7 @@ version = "2.13.3+1"
 [[deps.FriBidi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl"]
 git-tree-sha1 = "846f7026a9decf3679419122b49f8a1fdb48d2d5"
-git-tree-sha1 = "846f7026a9decf3679419122b49f8a1fdb48d2d5"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
-version = "1.0.16+0"
 version = "1.0.16+0"
 
 [[deps.FunctionChains]]
@@ -1075,9 +1069,7 @@ weakdeps = ["Dates", "Test"]
 
 [[deps.InvertedIndices]]
 git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
-git-tree-sha1 = "6da3c4316095de0f5ee2ebd875df8721e7e0bdbe"
 uuid = "41ab1584-1d38-5bbf-9106-f11c6c58b48f"
-version = "1.3.1"
 version = "1.3.1"
 
 [[deps.IrrationalConstants]]
@@ -1237,9 +1229,7 @@ version = "0.2.0"
 
 [[deps.LegendDSP]]
 deps = ["Adapt", "ArgCheck", "ArraysOfArrays", "DocStringExtensions", "FillArrays", "FunctionChains", "IntervalSets", "LIBSVM", "LegendDataTypes", "LinearAlgebra", "PropDicts", "RadiationDetectorDSP", "RadiationDetectorSignals", "Random", "Tables", "TypedTables", "Unitful"]
-git-tree-sha1 = "baafd482024fa1146557f0f37b791120f8159945"
-repo-rev = "main"
-repo-url = "https://github.com/legend-exp/LegendDSP.jl.git"
+path = "/home/iwsatlas1/henkes/.julia/dev/LegendDSP"
 uuid = "e6d7a502-be5c-5049-a927-8d60e566555d"
 version = "0.2.3"
 
@@ -1289,9 +1279,7 @@ weakdeps = ["Measurements"]
 
 [[deps.LegendSpecFits]]
 deps = ["ArgCheck", "ArraysOfArrays", "BAT", "ChangesOfVariables", "DensityInterface", "Distributions", "FillArrays", "Format", "ForwardDiff", "GaussianMixtures", "IntervalSets", "InverseFunctions", "IrrationalConstants", "KernelDensity", "LaTeXStrings", "LinearAlgebra", "LinearRegression", "LogExpFunctions", "LsqFit", "Measurements", "Measures", "Optim", "Optimization", "OptimizationBBO", "OptimizationNLopt", "OptimizationOptimJL", "PropDicts", "RadiationSpectra", "Random", "Roots", "SnoopPrecompile", "SpecialFunctions", "Statistics", "StatsBase", "StructArrays", "Tables", "TypedTables", "Unitful", "ValueShapes"]
-git-tree-sha1 = "3bee796d68c47c9b710e284fe4dac821095b925a"
-repo-rev = "main"
-repo-url = "https://github.com/legend-exp/LegendSpecFits.jl.git"
+path = "/home/iwsatlas1/henkes/.julia/dev/LegendSpecFits"
 uuid = "18221496-77af-46cf-bab8-820da09f7f97"
 version = "0.3.0"
 weakdeps = ["Plots", "RecipesBase"]
@@ -1329,9 +1317,7 @@ uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 [[deps.Libffi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "27ecae93dd25ee0909666e6835051dd684cc035e"
-git-tree-sha1 = "27ecae93dd25ee0909666e6835051dd684cc035e"
 uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
-version = "3.2.2+2"
 version = "3.2.2+2"
 
 [[deps.Libgcrypt_jll]]
@@ -1395,9 +1381,7 @@ version = "0.2.1"
 [[deps.LogExpFunctions]]
 deps = ["DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
 git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
-git-tree-sha1 = "13ca9e2586b89836fd20cccf56e57e2b9ae7f38f"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.29"
 version = "0.3.29"
 weakdeps = ["ChainRulesCore", "ChangesOfVariables", "InverseFunctions"]
 
@@ -1433,9 +1417,7 @@ version = "0.15.0"
 
 [[deps.MIMEs]]
 git-tree-sha1 = "1833212fd6f580c20d4291da9c1b4e8a655b128e"
-git-tree-sha1 = "1833212fd6f580c20d4291da9c1b4e8a655b128e"
 uuid = "6c6e2e6c-3030-632d-7369-2d6c69616d65"
-version = "1.0.0"
 version = "1.0.0"
 
 [[deps.MKL_jll]]
@@ -1612,9 +1594,7 @@ version = "0.5.5"
 
 [[deps.OffsetArrays]]
 git-tree-sha1 = "5e1897147d1ff8d98883cda2be2187dcf57d8f0c"
-git-tree-sha1 = "5e1897147d1ff8d98883cda2be2187dcf57d8f0c"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.15.0"
 version = "1.15.0"
 weakdeps = ["Adapt"]
 
@@ -1979,9 +1959,7 @@ version = "0.3.8"
 [[deps.RadiationSpectra]]
 deps = ["DelimitedFiles", "DensityInterface", "Distributions", "EmpiricalDistributions", "IntervalSets", "LinearAlgebra", "NamedTupleTools", "Optim", "Random123", "RecipesBase", "Requires", "SpecialFunctions", "StaticArrays", "StaticUnivariatePolynomials", "Statistics", "StatsBase", "ValueShapes"]
 git-tree-sha1 = "b1facfd4ea21a09d8c4c70067476bf7671e19b9e"
-git-tree-sha1 = "b1facfd4ea21a09d8c4c70067476bf7671e19b9e"
 uuid = "4f207c7e-01da-51d7-a1a0-c8c06dd1d883"
-version = "0.5.12"
 version = "0.5.12"
 
 [[deps.Random]]
@@ -2178,9 +2156,7 @@ version = "1.2.1"
 [[deps.SentinelArrays]]
 deps = ["Dates", "Random"]
 git-tree-sha1 = "712fb0231ee6f9120e005ccd56297abbc053e7e0"
-git-tree-sha1 = "712fb0231ee6f9120e005ccd56297abbc053e7e0"
 uuid = "91c51154-3ec4-41a3-a24f-3f23e20d615c"
-version = "1.4.8"
 version = "1.4.8"
 
 [[deps.Serialization]]
@@ -2561,9 +2537,7 @@ version = "1.3.243+0"
 [[deps.Wayland_jll]]
 deps = ["Artifacts", "EpollShim_jll", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
 git-tree-sha1 = "85c7811eddec9e7f22615371c3cc81a504c508ee"
-git-tree-sha1 = "85c7811eddec9e7f22615371c3cc81a504c508ee"
 uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
-version = "1.21.0+2"
 version = "1.21.0+2"
 
 [[deps.Wayland_protocols_jll]]
@@ -2629,10 +2603,7 @@ version = "1.0.12+0"
 [[deps.Xorg_libXcursor_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
 git-tree-sha1 = "807c226eaf3651e7b2c468f687ac788291f9a89b"
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
-git-tree-sha1 = "807c226eaf3651e7b2c468f687ac788291f9a89b"
 uuid = "935fb764-8cf2-53bf-bb30-45bb1f8bf724"
-version = "1.2.3+0"
 version = "1.2.3+0"
 
 [[deps.Xorg_libXdmcp_jll]]
@@ -2650,45 +2621,31 @@ version = "1.3.6+3"
 [[deps.Xorg_libXfixes_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
 git-tree-sha1 = "6fcc21d5aea1a0b7cce6cab3e62246abd1949b86"
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
-git-tree-sha1 = "6fcc21d5aea1a0b7cce6cab3e62246abd1949b86"
 uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
-version = "6.0.0+0"
 version = "6.0.0+0"
 
 [[deps.Xorg_libXi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
 git-tree-sha1 = "984b313b049c89739075b8e2a94407076de17449"
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
-git-tree-sha1 = "984b313b049c89739075b8e2a94407076de17449"
 uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
-version = "1.8.2+0"
 version = "1.8.2+0"
 
 [[deps.Xorg_libXinerama_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll"]
 git-tree-sha1 = "a1a7eaf6c3b5b05cb903e35e8372049b107ac729"
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll"]
-git-tree-sha1 = "a1a7eaf6c3b5b05cb903e35e8372049b107ac729"
 uuid = "d1454406-59df-5ea1-beac-c340f2130bc3"
-version = "1.1.5+0"
 version = "1.1.5+0"
 
 [[deps.Xorg_libXrandr_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
 git-tree-sha1 = "b6f664b7b2f6a39689d822a6300b14df4668f0f4"
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
-git-tree-sha1 = "b6f664b7b2f6a39689d822a6300b14df4668f0f4"
 uuid = "ec84b674-ba8e-5d96-8ba1-2a689ba10484"
-version = "1.5.4+0"
 version = "1.5.4+0"
 
 [[deps.Xorg_libXrender_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
 git-tree-sha1 = "a490c6212a0e90d2d55111ac956f7c4fa9c277a6"
-git-tree-sha1 = "a490c6212a0e90d2d55111ac956f7c4fa9c277a6"
 uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
-version = "0.9.11+1"
 version = "0.9.11+1"
 
 [[deps.Xorg_libpthread_stubs_jll]]
@@ -2706,9 +2663,7 @@ version = "1.17.0+3"
 [[deps.Xorg_libxkbfile_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libX11_jll"]
 git-tree-sha1 = "dbc53e4cf7701c6c7047c51e17d6e64df55dca94"
-git-tree-sha1 = "dbc53e4cf7701c6c7047c51e17d6e64df55dca94"
 uuid = "cc61e674-0454-545c-8b26-ed2c68acab7a"
-version = "1.1.2+1"
 version = "1.1.2+1"
 
 [[deps.Xorg_xcb_util_cursor_jll]]
@@ -2750,9 +2705,7 @@ version = "0.4.1+1"
 [[deps.Xorg_xkbcomp_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Xorg_libxkbfile_jll"]
 git-tree-sha1 = "ab2221d309eda71020cdda67a973aa582aa85d69"
-git-tree-sha1 = "ab2221d309eda71020cdda67a973aa582aa85d69"
 uuid = "35661453-b289-5fab-8a00-3d9160c6a3a4"
-version = "1.4.6+1"
 version = "1.4.6+1"
 
 [[deps.Xorg_xkeyboard_config_jll]]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,5 @@
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
-ClusterManagers = "34f1f09b-3a8b-5176-ab39-66d58a4d544e"
 ConcurrentCollections = "5060bff5-0b44-40c5-b522-fcd3ca5cecdd"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"

--- a/config/processing_config.json
+++ b/config/processing_config.json
@@ -29,7 +29,7 @@
         }
     },
     "processing": {
-        "periods": [3],
+        "periods": [3, 4, 6, 7, 8, 9],
         "runs" : "all",
         "analysis_runs_only": true,
         "only_partitions": false,
@@ -204,7 +204,7 @@
             "rank": 2,
             "kwargs": {
                 "reprocess": true,
-                "timeout": 1500
+                "timeout": 3000
             },
             "dependencies": ["process_peak_split"]
         },

--- a/config/processing_config.json
+++ b/config/processing_config.json
@@ -18,8 +18,8 @@
                 "julia_settings": []
             },
             "local": {
-                "n": 32,
-                "julia_settings": ["-t 2"]
+                "n": 64,
+                "julia_settings": []
             }
         },
         "env_variables": {
@@ -30,7 +30,6 @@
     },
     "processing": {
         "periods": [3],
-        "runs" : "all",
         "runs" : "all",
         "analysis_runs_only": true,
         "only_partitions": false,
@@ -56,7 +55,6 @@
             "rank": 2,
             "kwargs": {
                 "reprocess": true,
-                "max_wvfs": 15000,
                 "timeout": 0
             },
             "dependencies": []
@@ -68,7 +66,6 @@
             "rank": 3,
             "kwargs": {
                 "reprocess": true,
-                "max_wvfs": 15000,
                 "timeout": 0
             },
             "dependencies": []
@@ -197,8 +194,7 @@
             "rank": 1,
             "kwargs": {
                 "reprocess": true,
-                "timeout": 0,
-                "max_wvfs": 35000
+                "timeout": 0
             },
             "dependencies": ["process_peak_split"]
         },
@@ -208,8 +204,7 @@
             "rank": 2,
             "kwargs": {
                 "reprocess": true,
-                "timeout": 900,
-                "max_wvfs": 35000
+                "timeout": 1500
             },
             "dependencies": ["process_peak_split"]
         },

--- a/processors/p_process_aoe_calibration_cut.jl
+++ b/processors/p_process_aoe_calibration_cut.jl
@@ -34,6 +34,7 @@ function p_process_aoe_calibration_cut(processing_config::PropDict, l200::Legend
 
         @info "Processing channel $ch ($det)"
 
+        mkpath(joinpath(data_path(l200.par.ppars.aoe), string(det)))
         pars_db_ch = if isfile(joinpath(data_path(l200.par.ppars.aoe), "$det", "$part.json"))
             PropDict(l200.par.ppars.aoe[det, part])
         else

--- a/processors/p_process_aoe_cut.jl
+++ b/processors/p_process_aoe_cut.jl
@@ -33,6 +33,7 @@ function p_process_aoe_cut(processing_config::PropDict, l200::LegendData, period
 
         @info "Processing channel $ch ($det)"
 
+        mkpath(joinpath(data_path(l200.par.ppars.aoecut), string(det)))
         pars_db_ch = if isfile(joinpath(data_path(l200.par.ppars.aoecut), "$det", "$part.json"))
             PropDict(l200.par.ppars.aoecut[det, part])
         else

--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -38,6 +38,7 @@ function p_process_aoe_optimization(processing_config::PropDict, l200::LegendDat
 
         @info "Processing channel $ch ($det)"
 
+        mkpath(joinpath(data_path(l200.par.ppars.aoeopt), string(det)))
         pars_db_ch = if isfile(joinpath(data_path(l200.par.ppars.aoeopt), "$det", "$part.json"))
             PropDict(l200.par.ppars.aoeopt[det, part])
         else

--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -110,7 +110,7 @@ function p_process_aoe_optimization(processing_config::PropDict, l200::LegendDat
         wvfs_ch_sep_wdw, wvfs_ch_sep_pre, wvfs_ch_dep_wdw, wvfs_ch_dep_pre, presum_rate = nothing, nothing, nothing, nothing, nothing
         try
             @debug "Loading Tl208 SEP and DEP data from $(part), select $(ifelse(select_random, "randomly", "")) $n_evts events from each run"
-            data = load_partition_ch(lh5open, fast_flatten, l200, partinfo_ch, :jlpeaks, :cal, ch; data_keys=(:Tl208DEP_Bi212FEP, :Tl208SEP), n_evts=n_evts, select_random=select_random)
+            data = read_ldata((:Tl208DEP_Bi212FEP, :Tl208SEP), l200, DataTier(:jlpeaks), :cal, partinfo_ch, ch; n_evts=n_evts)
             wvfs_ch_dep_bi121fep_wdw = data.Tl208DEP_Bi212FEP.waveform_windowed[:]
             wvfs_ch_dep_bi121fep_pre = data.Tl208DEP_Bi212FEP.waveform_presummed[:]
             presum_rate              = data.Tl208SEP.presum_rate[1]

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -1,4 +1,4 @@
-function p_process_decay_time(processing_config::PropDict, l200::LegendData, period::DataPeriod,; reprocess::Bool=false, timeout::Int=0, max_wvfs::Int=15000, only_first_period::Bool=true)
+function p_process_decay_time(processing_config::PropDict, l200::LegendData, period::DataPeriod,; reprocess::Bool=false, timeout::Int=0, only_first_period::Bool=true)
     @info "Process decay time for all partitions containing period $period"
 
     rinfo = runinfo(l200, period)
@@ -36,6 +36,7 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         det = chinfo_ch.detector
         part = chinfo_ch.partition
 
+        mkpath(joinpath(data_path(l200.par.ppars.pz), string(det)))
         pars_db_ch = if isfile(joinpath(data_path(l200.par.ppars.pz), "$det", "$part.json"))
             PropDict(l200.par.ppars.pz[det, part])
         else
@@ -77,6 +78,7 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         nbins         = pz_config_ch.nbins
         rel_cut_fit   = pz_config_ch.rel_cut_fit
         n_evts        = pz_config_ch.n_evts
+        max_wvfs      = pz_config_ch.max_wvfs
         select_random = pz_config_ch.select_random
         peakname      = Symbol(pz_config_ch.peakname)
         qc_string     = pz_config_ch.qc
@@ -85,8 +87,8 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         wvfs_ch = nothing
         try
             @debug "Loading $peakname data from $(part), select $(ifelse(select_random, "randomly", "")) $n_evts events from each run"
-            data = load_partition_ch(lh5open, fast_flatten, l200, partinfo_ch, :jlpeaks, :cal, ch; data_keys=(peakname, ), n_evts=n_evts, select_random=select_random)
-            wvfs_ch = getproperty(data, peakname).waveform_presummed[:]
+            data = read_ldata(peakname, l200, DataTier(:jlpeaks), :cal, partinfo_ch, ch; n_evts=n_evts)
+            wvfs_ch = data.waveform_presummed[:]
             if length(wvfs_ch) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
                 wvfs_ch = wvfs_ch[rand(1:max_wvfs, max_wvfs)]
@@ -102,7 +104,7 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
             @debug "Get QC cuts"
             dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_ch, dsp_config_ch, 400.0u"µs", f_evaluate_qc)
             qc = ljl_propfunc(qc_string).(dsp_qc)
-            wvfs_ch = wvfs_ch[qc]
+            wvfs_ch = wvfs_ch[findall(qc)]
             @debug "Survival Fraction: $(round(count(qc) / length(qc) * 100, digits=2))%"
         catch e
             @error "Failed QC cuts: $(truncate_string(string(e)))"

--- a/processors/p_process_energy.jl
+++ b/processors/p_process_energy.jl
@@ -33,6 +33,7 @@ function p_process_energy(processing_config::PropDict, l200::LegendData, period:
 
         @debug "Processing channel $ch ($det)"
 
+        mkpath(joinpath(data_path(l200.par.ppars.ecal), string(det)))
         pars_db_ch = if isfile(joinpath(data_path(l200.par.ppars.ecal), "$det", "$part.json"))
             PropDict(l200.par.ppars.ecal[det, part])
         else

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -1,4 +1,4 @@
-function p_process_filter_optimization(processing_config::PropDict, l200::LegendData, period::DataPeriod,; reprocess::Bool=false, timeout::Int=0, max_wvfs::Int=15000, only_first_period::Bool=true)
+function p_process_filter_optimization(processing_config::PropDict, l200::LegendData, period::DataPeriod,; reprocess::Bool=false, timeout::Int=0, only_first_period::Bool=true)
     
     @info "Optimize filter for all partitions containing period $period"
 
@@ -66,6 +66,7 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
         
         # extract config
         n_evts        = optimization_config_ch.n_evts
+        max_wvfs      = optimization_config_ch.max_wvfs
         select_random = optimization_config_ch.select_random
         qc_string     = optimization_config_ch.qc
         peakname      = Symbol(optimization_config_ch.peakname)
@@ -109,10 +110,10 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
         wvfs_ch_pre, wvfs_ch_wdw, presum_rate = nothing, nothing, nothing
         try
             @debug "Loading $peakname data from $(part), select $(ifelse(select_random, "randomly", "")) $n_evts events from each run"
-            data = load_partition_ch(lh5open, fast_flatten, l200, partinfo_ch, :jlpeaks, :cal, ch; data_keys=(peakname, ), n_evts=n_evts, select_random=select_random)
-            wvfs_ch_pre = getproperty(data, peakname).waveform_presummed[:]
-            wvfs_ch_wdw = getproperty(data, peakname).waveform_windowed[:]
-            presum_rate = getproperty(data, peakname).presum_rate[:]
+            data = read_ldata(peakname, l200, DataTier(:jlpeaks), :cal, partinfo_ch, ch; n_evts=n_evts)
+            wvfs_ch_pre = data.waveform_presummed[:]
+            wvfs_ch_wdw = data.waveform_windowed[:]
+            presum_rate = data.presum_rate[:]
             if length(wvfs_ch_pre) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
                 sel = rand(1:max_wvfs, max_wvfs)
@@ -133,9 +134,9 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
             dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_ch_pre, dsp_config_ch, pars_tau[det].τ, f_evaluate_qc)
             qc = ljl_propfunc(qc_string).(dsp_qc)
             blmean_wdw = dsp_qc.blmean ./ presum_rate
-            wvfs_ch_pre = wvfs_ch_pre[qc]
-            wvfs_ch_wdw = wvfs_ch_wdw[qc]
-            blmean_wdw = blmean_wdw[qc]
+            wvfs_ch_pre = wvfs_ch_pre[findall(qc)]
+            wvfs_ch_wdw = wvfs_ch_wdw[findall(qc)]
+            blmean_wdw = blmean_wdw[findall(qc)]
             @debug "Survival Fraction: $(round(count(qc) / length(qc) * 100, digits=2))%"
         catch e
             @error "Failed QC cuts: $(truncate_string(string(e)))"
@@ -206,7 +207,8 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
                 GC.gc()
                 result_ft, report_ft = nothing, nothing
                 try
-                    result_ft, report_ft = fit_fwhm_ft(e_grid, e_grid_ft, qdrift, result_rt.rt, optimization_config_flt.min_e_fep, optimization_config_flt.max_e_fep, optimization_config_flt.rel_cut_fit_e_fep, optimization_config_ch.apply_ctc; n_bins=optimization_config_flt.nbins_e_fep, peak=optimization_config_ch.peak, window=(optimization_config_ch.left_window_size, optimization_config_ch.right_window_size))
+                    result_ft, report_ft = fit_fwhm_ft(e_grid, e_grid_ft, qdrift, result_rt.rt, optimization_config_flt.min_e_fep, optimization_config_flt.max_e_fep, optimization_config_flt.rel_cut_fit_e_fep, optimization_config_ch.apply_ctc; 
+                                            n_bins=optimization_config_flt.nbins_e_fep, peak=optimization_config_ch.peak, window=(optimization_config_ch.left_window_size, optimization_config_ch.right_window_size), ft_fwhm_tol=optimization_config_ch.ft_fwhm_tol)
                 catch e
                     @error "Failed $filter_type flat-top time extraction: $(truncate_string(string(e)))"
                     throw(ErrorException("Error in $filter_type flat-top time extraction: $(truncate_string(string(e)))"))
@@ -214,7 +216,7 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
                 @debug "Found optimal $filter_type FT at $(result_ft.ft) with FWHM $(round(u"keV", result_ft.min_fwhm, digits=2))"
                 yield()
                 
-                p = plot(report_ft)
+                p = plot(report_ft, ylims=(1, 15))
                 title!(p, get_plottitle(filekey_ch, part, det, "FEP FT Scan"; additiional_type=string(filter_type)))
                 savelfig(savefig, p, l200, part, filekey_ch, det, Symbol("fwhm_ft_scan_$(filter_type)"))
 

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -1,4 +1,4 @@
-function process_decay_time(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool=false, timeout::Int=0, max_wvfs::Int=15000)
+function process_decay_time(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool=false, timeout::Int=0)
         
     @info "Process decay time for period $period and run $run"
 
@@ -60,6 +60,7 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
         rel_cut_fit  = pz_config_ch.rel_cut_fit
         peakname     = Symbol(pz_config_ch.peakname)
         qc_string    = pz_config_ch.qc
+        max_wvfs     = pz_config_ch.max_wvfs
 
         filename = l200.tier[:jlpeaks, filekey, ch]
         if !isfile(filename)
@@ -90,7 +91,7 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
             @debug "Get QC cuts"
             dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_ch, dsp_config_ch, 400.0u"µs", f_evaluate_qc)
             qc = ljl_propfunc(qc_string).(dsp_qc)
-            wvfs_ch = wvfs_ch[qc]
+            wvfs_ch = wvfs_ch[findall(qc)]
             @debug "Survival Fraction: $(round(count(qc) / length(qc) * 100, digits=2))%"
         catch e
             @error "Failed QC cuts: $(truncate_string(string(e)))"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -30,7 +30,8 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
     pars_fltoptimization = get_values(merge(l200.par[pars_type, :fltopt](filekey), l200.par[pars_type, :aoeopt](filekey)))
     @debug "Loaded optimization parameters"
 
-    pars_sipm = get_values(l200.par[:rpars, :sipmopt](filekey))
+    mkpath(l200.par[pars_type, :sipmopt])
+    pars_sipm = get_values(l200.par[pars_type, :sipmopt](filekey))
     @debug "Loaded sipm parameters"
     
     if reprocess @info "Reprocess all filekeys and channels"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -9,12 +9,15 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
 
     chinfo      = channelinfo(l200, filekey; system=:geds, only_processable=true)
     chinfo_sipm = channelinfo(l200, filekey; system=:spms, only_processable=true)
+    chinfo_pmts = channelinfo(l200, filekey; system=:pmts, only_processable=true)
     @info "Loaded channel info with $(length(chinfo)) channels"
 
     dsp_config_pd = dataprod_config(l200).dsp(filekey)
     @debug "Loaded DSP config: $(dsp_config_pd)"
     dsp_meta_sipm = dataprod_config(l200).sipm(filekey)
     @debug "Loaded SiPM DSP config: $(dsp_meta_sipm)"
+    dsp_meta_pmt = dataprod_config(l200).pmt(filekey)
+    @debug "Loaded PMT DSP config: $(dsp_meta_pmt)"
 
     f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
         get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
@@ -30,7 +33,7 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
     pars_fltoptimization = get_values(merge(l200.par[pars_type, :fltopt](filekey), l200.par[pars_type, :aoeopt](filekey)))
     @debug "Loaded optimization parameters"
 
-    mkpath(l200.par[pars_type, :sipmopt])
+    mkpath(data_path(l200.par[pars_type, :sipmopt]))
     pars_sipm = get_values(l200.par[pars_type, :sipmopt](filekey))
     @debug "Loaded sipm parameters"
     
@@ -115,19 +118,17 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                         end
                     end
 
-                    @timeit dsp_timer "DSP" begin
-                        # loop over channels
-                        @showprogress desc="Filekey SiPM: $fk" output=stdout for chinfo_ch in chinfo_sipm
+                    # loop over channels
+                    if all(.!haskey.(Ref(raw_data), string.(chinfo_pmts.channel)))
+                        @warn "No PMT data found in $(fk), skip PMT processing"
+                        n_detectors += length(chinfo_pmts)
+                    else
+                        @showprogress desc="Filekey PMTS: $fk" output=stdout for chinfo_ch in chinfo_pmts
 
                             ch = chinfo_ch.channel
                             det = chinfo_ch.detector
             
                             # check if channel can be processed
-                            if !haskey(pars_sipm, det)
-                                @warn "No thresholds for detector $det, skip channel $ch"
-                                push!(failed_detectors, det)
-                                continue
-                            end
                             if "$ch" in processed_channels && !reprocess
                                 @info "Detector $det ($ch) already processed, skip"
                                 n_detectors += 1
@@ -137,11 +138,11 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                             @debug "Processing channel $ch ($det)"
                             @timeit dsp_timer "DSP $det" begin
                                 # get metadata
-                                dsp_meta_ch = merge(dsp_meta_sipm.default, get(dsp_meta_sipm, det, PropDict()))
+                                dsp_meta_ch = merge(dsp_meta_pmt.default, get(dsp_meta_pmt, det, PropDict()))
                                 # process channel
                                 outdata_ch = nothing
                                 try
-                                    outdata_ch = dsp_sipm_compressed(raw_data[ch].raw[:], dsp_meta_ch, pars_sipm[det])
+                                    outdata_ch = dsp_pmts(raw_data[ch].raw[:], dsp_meta_ch)
                                 catch e
                                     if e isa TaskFailedException
                                         e = e.task.exception
@@ -160,6 +161,52 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                                 flush(stdout)
                                 flush(stderr)
                             end
+                        end
+                    end
+
+                    # loop over channels
+                    @showprogress desc="Filekey SiPM: $fk" output=stdout for chinfo_ch in chinfo_sipm
+
+                        ch = chinfo_ch.channel
+                        det = chinfo_ch.detector
+        
+                        # check if channel can be processed
+                        if !haskey(pars_sipm, det)
+                            @warn "No thresholds for detector $det, skip channel $ch"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        if "$ch" in processed_channels && !reprocess
+                            @info "Detector $det ($ch) already processed, skip"
+                            n_detectors += 1
+                            continue
+                        end
+        
+                        @debug "Processing channel $ch ($det)"
+                        @timeit dsp_timer "DSP $det" begin
+                            # get metadata
+                            dsp_meta_ch = merge(dsp_meta_sipm.default, get(dsp_meta_sipm, det, PropDict()))
+                            # process channel
+                            outdata_ch = nothing
+                            try
+                                outdata_ch = dsp_sipm_compressed(raw_data[ch].raw[:], dsp_meta_ch, pars_sipm[det])
+                            catch e
+                                if e isa TaskFailedException
+                                    e = e.task.exception
+                                end
+                                @error "Error processing channel $ch ($det) in $(fk): $(truncate_string(string(e)))"
+                                push!(failed_detectors, det)
+                                continue
+                            end
+                            # save data to hdf5
+                            outdata[ch, :jldsp] = outdata_ch
+                            # free memory
+                            GC.gc()
+                            # count number of detectors processed and Successful
+                            n_detectors += 1
+                            # flush streams
+                            flush(stdout)
+                            flush(stderr)
                         end
                     end
 
@@ -282,7 +329,7 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
         total_allocated = Base.format_bytes(TimerOutputs.totallocated(dsp_timer))
         
         # create log
-        log_fk = log_nt((fk, ProcessStatus(1), "$(n_detectors)/$(length(chinfo)+length(get(dsp_config_pd, :additional_channel, []))+length(chinfo_sipm))", string.(failed_detectors), total_time, total_allocated, ""))
+        log_fk = log_nt((fk, ProcessStatus(ifelse(isempty(failed_detectors), 1, 0)), "$(n_detectors)/$(length(chinfo)+length(get(dsp_config_pd, :additional_channel, []))+length(chinfo_sipm)+length(chinfo_pmts))", string.(failed_detectors), total_time, total_allocated, ""))
 
         return (timer = dsp_timer, log = log_fk, processed = true)
     end

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -188,7 +188,8 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
                 GC.gc()
                 result_ft, report_ft = nothing, nothing
                 try
-                    result_ft, report_ft = fit_fwhm_ft(e_grid, e_grid_ft, qdrift, result_rt.rt, optimization_config_flt.min_e_fep, optimization_config_flt.max_e_fep, optimization_config_flt.rel_cut_fit_e_fep, optimization_config_ch.apply_ctc; n_bins=optimization_config_flt.nbins_e_fep, peak=optimization_config_ch.peak, window=(optimization_config_ch.left_window_size, optimization_config_ch.right_window_size))
+                    result_ft, report_ft = fit_fwhm_ft(e_grid, e_grid_ft, qdrift, result_rt.rt, optimization_config_flt.min_e_fep, optimization_config_flt.max_e_fep, optimization_config_flt.rel_cut_fit_e_fep, optimization_config_ch.apply_ctc; 
+                                            n_bins=optimization_config_flt.nbins_e_fep, peak=optimization_config_ch.peak, window=(optimization_config_ch.left_window_size, optimization_config_ch.right_window_size), ft_fwhm_tol=optimization_config_ch.ft_fwhm_tol)
                 catch e
                     @error "Failed $filter_type flat-top time extraction: $(truncate_string(string(e)))"
                     throw(ErrorException("Error in $filter_type flat-top time extraction: $(truncate_string(string(e)))"))

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -1,4 +1,4 @@
-function process_filter_optimization(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool=false, timeout::Int=0, max_wvfs::Int=15000)
+function process_filter_optimization(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool=false, timeout::Int=0)
     
     @info "Optimize filter for period $period and run $run"
 
@@ -83,6 +83,8 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
         end
         yield()
 
+        max_wvfs = optimization_config_ch.max_wvfs
+
         # load data
         wvfs_ch_pre, wvfs_ch_wdw, presum_rate = nothing, nothing, nothing
         try
@@ -112,9 +114,9 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
             dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_ch_pre, dsp_config_ch, pars_tau[det].τ, f_evaluate_qc)
             qc = ljl_propfunc(qc_string).(dsp_qc)
             blmean_wdw = dsp_qc.blmean ./ presum_rate
-            wvfs_ch_pre = wvfs_ch_pre[qc]
-            wvfs_ch_wdw = wvfs_ch_wdw[qc]
-            blmean_wdw = blmean_wdw[qc]
+            wvfs_ch_pre = wvfs_ch_pre[findall(qc)]
+            wvfs_ch_wdw = wvfs_ch_wdw[findall(qc)]
+            blmean_wdw = blmean_wdw[findall(qc)]
             @debug "Survival Fraction: $(round(count(qc) / length(qc) * 100, digits=2))%"
         catch e
             @error "Failed QC cuts: $(truncate_string(string(e)))"

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -1,6 +1,5 @@
 using LegendDataManagement
 using ConcurrentCollections
-import ClusterManagers
 using ParallelProcessingTools
 using ParallelProcessingTools: getlabel
 


### PR DESCRIPTION
This PR contains:
- Bug fixes to partition processor in case the outpath paths for the `jlpar` are not yet created
- Updates to `processing_config.json`
- Replacement of legacy `load_partitionch`  function by `read_ldata`
- Removed `ClusterManagers` from `Project.toml`
- Bug fix `max_wvfs` condition in optimization processors
- Added PMT DSP (Thanks to @MayaMenzel)
- Bug Fix QC cut conditions by using `findall` consistently
