### PR TITLE
adapt data flow to LegendSpecFits/simple_calibration PR

### DIFF
--- a/processors/p_process_energy.jl
+++ b/processors/p_process_energy.jl
@@ -104,11 +104,11 @@ function p_process_energy(processing_config::PropDict, l200::LegendData, period:
                 end
                 GC.gc()
 
-                e_unit = u"keV"
+                const e_unit = u"keV"
                 peakhists, peakstats = nothing, nothing
                 try
                     @debug "Get $e_type peakhists and peakstats"
-                    peakhists, peakstats, _, _ = get_peakhists_th228(collect(energy), energy_config_ch.th228_lines, energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes; e_unit=e_unit)
+                    peakhists, peakstats, _, _ = peakhists_gamma(collect(energy), energy_config_ch.th228_lines, energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes)
                 catch e
                     @error "Error in $e_type simple calibration for channel $ch: $(truncate_error(e))"
                     throw(ErrorException("Error in $e_type simple calibration"))

--- a/processors/process_ct_correction.jl
+++ b/processors/process_ct_correction.jl
@@ -90,7 +90,7 @@ function process_ct_correction(processing_config::PropDict, l200::LegendData, pe
                 result_simple, report_simple = nothing, nothing
                 try
                     @debug "Get $e_type simple calibration"
-                    result_simple, report_simple = simple_calibration(getproperty(data_ch_after_qc, e_type), energy_config_ch.th228_lines, energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes,; calib_type=:th228, n_bins=energy_config_ch.n_bins, quantile_perc=quantile_perc)
+                    result_simple, report_simple = simple_calibration(getproperty(data_ch_after_qc, e_type), energy_config_ch.th228_lines, energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes,; calib_type=:th228, quantile_perc=quantile_perc, binning_peak_window=energy_config_ch.binning_peak_window)
                 catch e
                     @error "Error in $e_type simple calibration for channel $ch: $(truncate_error(e))"
                     throw(ErrorException("Error in $e_type simple calibration"))

--- a/processors/process_energy_calibration.jl
+++ b/processors/process_energy_calibration.jl
@@ -104,7 +104,7 @@ function process_energy_calibration(processing_config::PropDict, l200::LegendDat
                 result_simple, report_simple = nothing, nothing
                 try
                     @debug "Get $e_type simple calibration"
-                    result_simple, report_simple = simple_calibration(e_uncal, energy_config_ch.th228_lines, energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes,; calib_type=:th228, n_bins=energy_config_ch.n_bins, quantile_perc=quantile_perc, binning_peak_window=energy_config_ch.binning_peak_window)
+                    result_simple, report_simple = simple_calibration(e_uncal, energy_config_ch.th228_lines, energy_config_ch.left_window_sizes, energy_config_ch.right_window_sizes,; calib_type=:th228, quantile_perc=quantile_perc, binning_peak_window=energy_config_ch.binning_peak_window)
                 catch e
                     @error "Error in $e_type simple calibration for channel $ch: $(truncate_error(e))"
                     throw(ErrorException("Error in $e_type simple calibration"))


### PR DESCRIPTION
- adapt dataflow to  LegendSpecFits PR https://github.com/legend-exp/LegendSpecFits.jl/pull/149 
- tested on a single detector / run; worked fine. 
@theHenks Could you run the ct-correction and energy calibration once for all dets?