### PR TITLE
added lq_normalization; updated plot filenames

### DIFF
--- a/processors/p_process_lq_calibration_cut.jl
+++ b/processors/p_process_lq_calibration_cut.jl
@@ -15,7 +15,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
     # create log line Tuple
     log_nt_cal = NamedTuple{(:Channel, :Detector, :Partition, :Status, Symbol("Classifier Type"), Symbol("DT Corr. Type"), Symbol("Correction Slope"), :CalError)}
-    log_nt_cut = NamedTuple{(:Channel, :Detector, :Partition, :Status, Symbol("Classifier Type"), Symbol("Cut Value"), Symbol("DEP SF"), Symbol("CC SF"), :CutError)}
+    log_nt_cut = NamedTuple{(:Channel, :Detector, :Partition, :Status, Symbol("Classifier Type"), Symbol("High Cut"), Symbol("DEP SF"), Symbol("CC SF"), :CutError)}
 
     # get worker pool
     wpool = get_workerPool(processing_config, nameof(var"#self#"))
@@ -76,13 +76,13 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
         pol_fit_order               = lq_config_ch.pol_fit_order
         ctc_uncertainty             = lq_config_ch.ctc_uncertainty
 
-        #for lq_cut
-        cut_sigma                   = lq_config_ch.cut_sigma
+        #for lq_norm
         dep_sideband_sigma          = lq_config_ch.dep_sideband_sigma
         cut_truncation_sigma        = lq_config_ch.cut_truncation_sigma
         cut_uncertainty             = lq_config_ch.cut_uncertainty
 
         #for get_peaks_survival_fractions
+        high_cut_sigma              = lq_config_ch.high_cut_sigma
         lq_peaks_names              = Symbol.(lq_config_ch.lq_peaks_names)
         lq_peaks                    = lq_config_ch.lq_peaks
         lq_peaks_windows_left       = lq_config_ch.lq_peaks_windows_left
@@ -167,7 +167,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
                     std_lq = std(filter(isfinite, lq_e_corr))
                     median_lq = median(filter(isfinite, lq_e_corr))
 
-                    #normalization
+                    # pre normalization
                     cuts_lq = cut_single_peak(lq_e_corr, 0.0, quantile(filter(isfinite, lq_e_corr), 0.99); n_bins=-1)
                     lq_e_corr ./= cuts_lq.max
 
@@ -178,28 +178,64 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
                     throw(ErrorException("Error in energy correction and normalization: $e"))
                 end
 
-                @debug "Calibrate $lq_type"
+                @debug "Drift time correction of $lq_type"
                 drift_result, drift_report = nothing, nothing
                 try 
                     drift_result, drift_report = lq_ctc_correction(lq_e_corr, dt_eff, e_cal, dep_µ, dep_σ;
                     ctc_dep_edgesigma, ctc_lq_precut_relative_cut, lq_outlier_sigma, ctc_driftime_cutoff_method, dt_eff_outlier_sigma, lq_e_corr_expression, dt_eff_expression, ctc_dt_eff_low_quantile, ctc_dt_eff_high_quantile, pol_fit_order, uncertainty=ctc_uncertainty)
                 catch e
-                    @error "Error in drift time correction: $e"
-                    throw(ErrorException("Error in drift time correction: $e"))
+                    @error "Error in drift time correction: $(truncate_error(e))"
+                    throw(ErrorException("Error in drift time correction: $(truncate_error(e))"))
                 end
 
-                #create and save plots
+                # create and save plots
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :DEP, title = "Drift Time vs LQ in DEP for Detector: $det", figsize = (620,400))
                 savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_ctc_DEP_$lq_type"))
 
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :whole, title = "Drift Time vs LQ for Detector: $det", figsize = (620,400))
                 savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_ctc_$lq_type"))
 
-                #create log entry
+
+                # create lq normalization                
+                lq_ctc = nothing
+                lq_class_expression = nothing
+                result, report = nothing, nothing
+                lq_class = nothing
+                try
+                    lq_class_expression = drift_result.func
+                    lq_ctc = ljl_propfunc(lq_class_expression).(hit_cal)
+
+                    result, report = lq_norm(dep_µ, dep_σ, e_cal, lq_ctc; 
+                    dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
+                    
+                    lq_class = ljl_propfunc(result.func).(hit_cal)
+                catch e
+                    @error "Error in LQ normalization calculation: $(truncate_error(e))"
+                    throw(ErrorException("Error in LQ normalization calculation: $(truncate_error(e))"))
+                end
+
+                # create and save plots
+                p = LegendMakie.lplot(report.fit_report, xlabel = Makie.rich("LQ", Makie.subscript(" ctc")), digits = 3, figsize = (600,450), 
+                    legend_position = :none, title = get_plottitle(filekey_ch, part, det, "LQ DEP fit", additional_type=string(lq_type)))
+                Makie.axislegend(position = :lt)
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_dep_normalization_$lq_type"))
+
+                p = LegendMakie.lplot(report.temp_hists, 
+                    title = get_plottitle(filekey_ch, part, det, "LQ sidebands", additional_type=string(lq_type)), 
+                    xlims = (StatsBase.quantile.(Ref(filter(isfinite, lq_ctc),), (0.05, 0.95)))
+                )
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_sidebands_$lq_type"))
+
+                p = LegendMakie.lplot((; e_cal, edges = report.edges, dep_σ = report.dep_σ),
+                    title = get_plottitle(filekey_ch, part, det, "LQ side bands", additional_type=string(lq_type)))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_sideband_position_$lq_type"))
+
+
+                # create log entry
                 log_info = log_nt_cal(ch, det, part, ProcessStatus(1), lq_type, ctc_driftime_cutoff_method, drift_result.fit_result.par[1], "-")
 
                 # add results to dict
-                result_dict[lq_type]   =  merge(drift_result, (mean_lq = mean_lq, std_lq = std_lq, median_lq = median_lq))
+                result_dict[lq_type]   =  merge(result, (drift_result = drift_result, mean_lq = mean_lq, std_lq = std_lq, median_lq = median_lq))
                 log_info_dict[lq_type] = log_info
                 processed_dict[lq_type] = true
 
@@ -232,62 +268,33 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
                 # get lq classifier and lq classifier expression
                 lq_class = nothing
-                lq_class_expression = nothing
                 try
-                    lq_class_expression = pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func
-                    lq_class = ljl_propfunc(lq_class_expression).(hit_cal)
+                    norm_func = pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func
+                    lq_class = ljl_propfunc(norm_func).(hit_cal)
                 catch e
                     @error "lq classifier for $det from cannot be loaded: $(truncate_error(e))"
                     throw(LoadError("lq", 154, "lq classifier data for $det from partition $(part) cannot be loaded: $(truncate_error(e))"))
                 end
-                
-                #calculate LQ cut parameter value and normalized lq
-                result, report = nothing, nothing
-                lq_norm = nothing
-                try
-                    result, report = lq_cut(dep_µ, dep_σ, e_cal, lq_class; 
-                    cut_sigma, dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
-                    lq_norm = ljl_propfunc(result.lq_norm_func).(hit_cal)
-                catch e
-                    @error "Error in LQ cut calculation: $e"
-                    throw(ErrorException("Error in LQ cut calculation: $e"))
-                end
 
-                #create and save plots
-                p = LegendMakie.lplot(report.fit_report, xlabel = Makie.rich("LQ", Makie.subscript(" ctc")), digits = 3, figsize = (600,450), 
-                    legend_position = :none, title = get_plottitle(filekey_ch, part, det, "LQ DEP fit", additional_type=string(lq_classifier)))
-                Makie.vlines!(Measurements.value(report.cut), color = LegendMakie.CoaxGreen, label = "Cut Value", linewidth = 4)
-                Makie.axislegend(position = :lt)
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_dep_fit_$lq_classifier"))
-
-                p = LegendMakie.lplot(report.temp_hists, 
-                    title = get_plottitle(filekey_ch, part, det, "LQ sidebands", additional_type=string(lq_classifier)), 
-                    xlims = (StatsBase.quantile.(Ref(filter(isfinite, lq_class),), (0.05, 0.95)))
-                )
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_sidebands_$lq_classifier"))
-
-                p = LegendMakie.lplot((; e_cal, edges = report.edges, dep_σ = report.dep_σ),
-                    title = get_plottitle(filekey_ch, part, det, "LQ side bands", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_sideband_window_$lq_classifier"))
-
-                sel = isfinite.(e_cal) #.&& drift_report.dep_left .< e_cal .< drift_report.dep_right
-                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_norm[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
+                # create and save plots
+                sel = isfinite.(e_cal)
+                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_class[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
                     title = get_plottitle(filekey_ch, part, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" norm")), limits = (0,3000,-5.5,9.5))
-                Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
+                Makie.hlines!([high_cut_sigma], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
                 Makie.axislegend(position = :rb)
                 LegendMakie.add_watermarks!(position = "outer top", final = true)
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_energy_vs_lq_norm_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_classalized_$lq_classifier"))
 
-                p = LegendMakie.lplot((; e_cal, lq_class, cut_value = report.cut), figsize = (750,400),
+                p = LegendMakie.lplot((; e_cal, lq_class, cut_value = high_cut_sigma), figsize = (750,400),
                     title = get_plottitle(filekey_ch, part, det, "LQ Performance", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_energy_histogram_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_energy_after_$lq_classifier"))
                 
 
                 @debug("Generate Survival Fractions for LQ")
 
                 result_peaks, report_peaks = nothing, nothing
                 try
-                    result_peaks, report_peaks = get_peaks_survival_fractions(lq_class, e_cal, lq_peaks, lq_peaks_names, lq_peaks_windows_left, lq_peaks_windows_right, result.cut; inverted_mode=true, fit_funcs=lq_peaks_fit_funcs)
+                    result_peaks, report_peaks = get_peaks_survival_fractions(lq_class, e_cal, lq_peaks, lq_peaks_names, lq_peaks_windows_left, lq_peaks_windows_right, high_cut_sigma; inverted_mode=true, fit_funcs=lq_peaks_fit_funcs)
                 catch e
                     @error "Error in peak lq survival fraction calculation: $e"
                     throw(ErrorException("Error in peak lq survival fraction calculation: $e"))
@@ -295,7 +302,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
                 result_qbb, report_qbb = nothing, nothing
                 try
-                    result_qbb, report_qbb = get_continuum_survival_fraction(lq_class, e_cal, qbb_pos, qbb_window, result.cut, inverted_mode=true)
+                    result_qbb, report_qbb = get_continuum_survival_fraction(lq_class, e_cal, qbb_pos, qbb_window, high_cut_sigma, inverted_mode=true)
                 catch e
                     @error "Error in qbb lq survival fraction calculation: $e"
                     throw(ErrorException("Error in qbb lq survival fraction calculation: $e"))
@@ -303,7 +310,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
 
                 # save results
-                final_result = merge(result, (peaks = result_peaks, qbb = result_qbb))
+                final_result = (cut = high_cut_sigma, peaks = result_peaks, qbb = result_qbb)
 
                 log_info = log_nt_cut((ch, det, part, ProcessStatus(1), lq_classifier, final_result.cut, final_result.peaks[:Tl208DEP].sf, final_result.qbb.sf, "-"))
 

--- a/processors/p_process_lq_calibration_cut.jl
+++ b/processors/p_process_lq_calibration_cut.jl
@@ -171,7 +171,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
                     cuts_lq = cut_single_peak(lq_e_corr, 0.0, quantile(filter(isfinite, lq_e_corr), 0.99); n_bins=-1)
                     lq_e_corr ./= cuts_lq.max
 
-                    lq_e_corr_expression = "$(lq_funcs[lq_type]) / $(cuts_lq.max)"
+                    lq_e_corr_expression = "( ( $(lq_funcs[lq_type]) ) / $(cuts_lq.max) )"
                     dt_eff_expression = qdrift_expression
                 catch e
                     @error "Error in energy correction and normalization: $e"
@@ -190,10 +190,10 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
                 #create and save plots
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :DEP, title = "Drift Time vs LQ in DEP for Detector: $det", figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("drift_time_vs_lq_plot_DEP_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_drift_time_vs_lq_plot_DEP_$lq_type"))
 
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :whole, title = "Drift Time vs LQ for Detector: $det", figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("drift_time_vs_lq_plot_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_drift_time_vs_lq_plot_$lq_type"))
 
                 #create log entry
                 log_info = log_nt_cal(ch, det, part, ProcessStatus(1), lq_type, ctc_driftime_cutoff_method, drift_result.fit_result.par[1], "-")
@@ -230,19 +230,24 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
             try
                 @debug "Generate lq cut"
 
-                #get lq classifier
+                # get lq classifier and lq classifier expression
                 lq_class = nothing
+                lq_class_expression = nothing
                 try
-                    lq_class = ljl_propfunc(pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func).(hit_cal)
+                    lq_class_expression = pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func
+                    lq_class = ljl_propfunc(lq_class_expression).(hit_cal)
                 catch e
-                    @error "lq classifier for $det from cannot be loaded"
-                    throw(LoadError("lq", 154, "lq classifier data for $det from partition $(part) cannot be loaded"))
+                    @error "lq classifier for $det from cannot be loaded: $(truncate_error(e))"
+                    throw(LoadError("lq", 154, "lq classifier data for $det from partition $(part) cannot be loaded: $(truncate_error(e))"))
                 end
                 
-                #calculate LQ cut parameter value
+                #calculate LQ cut parameter value and normalized lq
                 result, report = nothing, nothing
+                lq_norm = nothing
                 try
-                    result, report = lq_cut(dep_µ, dep_σ, e_cal, lq_class; cut_sigma, dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty)
+                    result, report = lq_cut(dep_µ, dep_σ, e_cal, lq_class; 
+                    cut_sigma, dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
+                    lq_norm = ljl_propfunc(result.lq_norm_func).(hit_cal)
                 catch e
                     @error "Error in LQ cut calculation: $e"
                     throw(ErrorException("Error in LQ cut calculation: $e"))
@@ -250,35 +255,35 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
                 #create and save plots
                 p = LegendMakie.lplot(report.fit_report, xlabel = Makie.rich("LQ", Makie.subscript(" ctc")), digits = 3, figsize = (600,450), 
-                    legend_position = :none, title = get_plottitle(filekey_ch, part, det, "LQ Cut", additional_type=string(lq_classifier)))
+                    legend_position = :none, title = get_plottitle(filekey_ch, part, det, "LQ DEP fit", additional_type=string(lq_classifier)))
                 Makie.vlines!(Measurements.value(report.cut), color = LegendMakie.CoaxGreen, label = "Cut Value", linewidth = 4)
                 Makie.axislegend(position = :lt)
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_cut_fit_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_dep_fit_$lq_classifier"))
 
                 p = LegendMakie.lplot(report.temp_hists, 
                     title = get_plottitle(filekey_ch, part, det, "LQ sidebands", additional_type=string(lq_classifier)), 
                     xlims = (StatsBase.quantile.(Ref(filter(isfinite, lq_class),), (0.05, 0.95)))
                 )
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("sideband_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_sidebands_$lq_classifier"))
 
                 p = LegendMakie.lplot((; e_cal, edges = report.edges, dep_σ = report.dep_σ),
                     title = get_plottitle(filekey_ch, part, det, "LQ side bands", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_cut_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_sideband_window_$lq_classifier"))
 
                 sel = isfinite.(e_cal) #.&& drift_report.dep_left .< e_cal .< drift_report.dep_right
-                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_class[sel]), (0:1:3000, range(-3.5, 5.5, length=200))),
-                    title = get_plottitle(filekey_ch, part, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" ctc")), limits = (0,3000,-3.5,5.5))
-                Makie.hlines!([Measurements.value(report.cut)], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
-                Makie.axislegend(position = :rb)
+                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_norm[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
+                    title = get_plottitle(filekey_ch, part, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" norm")), limits = (0,3000,-5.5,9.5))
+                #Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
+                #Makie.axislegend(position = :rb)
                 LegendMakie.add_watermarks!(position = "outer top", final = true)
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("energy_hist_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_energy_vs_lq_norm_$lq_classifier"))
 
                 p = LegendMakie.lplot((; e_cal, lq_class, cut_value = report.cut), figsize = (750,400),
                     title = get_plottitle(filekey_ch, part, det, "LQ Performance", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("cut_fraction_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_energy_histogram_$lq_classifier"))
                 
 
-                @debug("Generate Surrvival Fractions for LQ")
+                @debug("Generate Survival Fractions for LQ")
 
                 result_peaks, report_peaks = nothing, nothing
                 try

--- a/processors/p_process_lq_calibration_cut.jl
+++ b/processors/p_process_lq_calibration_cut.jl
@@ -196,19 +196,16 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
                 savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_ctc_$lq_type"))
 
 
-                # create lq normalization                
+                # create lq normalization
+                lq_class_expression = drift_result.func                
                 lq_ctc = nothing
-                lq_class_expression = nothing
                 result, report = nothing, nothing
-                lq_class = nothing
                 try
                     lq_class_expression = drift_result.func
                     lq_ctc = ljl_propfunc(lq_class_expression).(hit_cal)
 
                     result, report = lq_norm(dep_µ, dep_σ, e_cal, lq_ctc; 
                     dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
-                    
-                    lq_class = ljl_propfunc(result.func).(hit_cal)
                 catch e
                     @error "Error in LQ normalization calculation: $(truncate_error(e))"
                     throw(ErrorException("Error in LQ normalization calculation: $(truncate_error(e))"))

--- a/processors/p_process_lq_calibration_cut.jl
+++ b/processors/p_process_lq_calibration_cut.jl
@@ -307,9 +307,9 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
 
                 # save results
-                final_result = (cut = high_cut_sigma, peaks = result_peaks, qbb = result_qbb)
+                final_result = (highcut = high_cut_sigma, peaks = result_peaks, qbb = result_qbb)
 
-                log_info = log_nt_cut((ch, det, part, ProcessStatus(1), lq_classifier, final_result.cut, final_result.peaks[:Tl208DEP].sf, final_result.qbb.sf, "-"))
+                log_info = log_nt_cut((ch, det, part, ProcessStatus(1), lq_classifier, final_result.highcut, final_result.peaks[:Tl208DEP].sf, final_result.qbb.sf, "-"))
 
                 # add results to dict
                 result_dict[lq_classifier] = final_result

--- a/processors/p_process_lq_calibration_cut.jl
+++ b/processors/p_process_lq_calibration_cut.jl
@@ -171,7 +171,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
                     cuts_lq = cut_single_peak(lq_e_corr, 0.0, quantile(filter(isfinite, lq_e_corr), 0.99); n_bins=-1)
                     lq_e_corr ./= cuts_lq.max
 
-                    lq_e_corr_expression = "( ( $(lq_funcs[lq_type]) ) / $(cuts_lq.max) )"
+                    lq_e_corr_expression = "( $(lq_funcs[lq_type]) ) / $(cuts_lq.max)"
                     dt_eff_expression = qdrift_expression
                 catch e
                     @error "Error in energy correction and normalization: $e"
@@ -190,10 +190,10 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
 
                 #create and save plots
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :DEP, title = "Drift Time vs LQ in DEP for Detector: $det", figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_drift_time_vs_lq_plot_DEP_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_ctc_DEP_$lq_type"))
 
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :whole, title = "Drift Time vs LQ for Detector: $det", figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_drift_time_vs_lq_plot_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_ctc_$lq_type"))
 
                 #create log entry
                 log_info = log_nt_cal(ch, det, part, ProcessStatus(1), lq_type, ctc_driftime_cutoff_method, drift_result.fit_result.par[1], "-")
@@ -273,8 +273,8 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
                 sel = isfinite.(e_cal) #.&& drift_report.dep_left .< e_cal .< drift_report.dep_right
                 p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_norm[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
                     title = get_plottitle(filekey_ch, part, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" norm")), limits = (0,3000,-5.5,9.5))
-                #Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
-                #Makie.axislegend(position = :rb)
+                Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
+                Makie.axislegend(position = :rb)
                 LegendMakie.add_watermarks!(position = "outer top", final = true)
                 savelfig(LegendMakie.lsavefig, p, l200, part, filekey_ch, det, Symbol("lq_energy_vs_lq_norm_$lq_classifier"))
 

--- a/processors/process_lq_calibration_cut.jl
+++ b/processors/process_lq_calibration_cut.jl
@@ -135,7 +135,7 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                     cuts_lq = cut_single_peak(lq_e_corr, 0.0, quantile(filter(isfinite, lq_e_corr), 0.99); n_bins=-1)
                     lq_e_corr ./= cuts_lq.max
 
-                    lq_e_corr_expression = "( ( $(lq_funcs[lq_type]) ) / $(cuts_lq.max) )"
+                    lq_e_corr_expression = "( $(lq_funcs[lq_type]) ) / $(cuts_lq.max)"
                     dt_eff_expression = qdrift_expression
                 catch e
                     @error "Error in energy correction and normalization: $e"
@@ -154,10 +154,10 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
 
                 #create and save plots
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :DEP, title = get_plottitle(filekey, det, "LQ"), figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_drift_time_vs_lq_plot_DEP_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_ctc_DEP_$lq_type"))
 
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :whole, title = get_plottitle(filekey, det, "LQ"), figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_drift_time_vs_lq_plot_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_ctc_$lq_type"))
 
                 #create log entry
                 log_info = log_nt_cal(ch, det, ProcessStatus(1), lq_type, ctc_driftime_cutoff_method, drift_result.fit_result.par[1], "-")
@@ -236,8 +236,8 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                 sel = isfinite.(e_cal) #.&& drift_report.dep_left .< e_cal .< drift_report.dep_right
                 p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_norm[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
                     title = get_plottitle(filekey, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" norm")), limits = (0,3000,-5.5,9.5))
-                #Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
-                #Makie.axislegend(position = :rb)
+                Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
+                Makie.axislegend(position = :rb)
                 LegendMakie.add_watermarks!(position = "outer top", final = true)
                 savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_energy_vs_lq_norm_$lq_classifier"))
 

--- a/processors/process_lq_calibration_cut.jl
+++ b/processors/process_lq_calibration_cut.jl
@@ -160,19 +160,15 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                 savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_ctc_$lq_type"))
 
 
-                # create lq normalization                
+                # create lq normalization
+                lq_class_expression = drift_result.func                
                 lq_ctc = nothing
-                lq_class_expression = nothing
                 result, report = nothing, nothing
-                lq_class = nothing
                 try
-                    lq_class_expression = drift_result.func
                     lq_ctc = ljl_propfunc(lq_class_expression).(hit_cal)
 
                     result, report = lq_norm(dep_µ, dep_σ, e_cal, lq_ctc; 
                     dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
-                    
-                    lq_class = ljl_propfunc(result.func).(hit_cal)
                 catch e
                     @error "Error in LQ normalization calculation: $(truncate_error(e))"
                     throw(ErrorException("Error in LQ normalization calculation: $(truncate_error(e))"))

--- a/processors/process_lq_calibration_cut.jl
+++ b/processors/process_lq_calibration_cut.jl
@@ -23,7 +23,7 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
 
     # create log line Tuple
     log_nt_cal = NamedTuple{(:Channel, :Detector, :Status, Symbol("Classifier Type"), Symbol("DT Corr. Type"), Symbol("Correction Slope"), :CalError)}
-    log_nt_cut = NamedTuple{(:Channel, :Detector, :Status, Symbol("Classifier Type"), Symbol("Cut Value"), Symbol("DEP SF"), Symbol("CC SF"), :CutError)}
+    log_nt_cut = NamedTuple{(:Channel, :Detector, :Status, Symbol("Classifier Type"), Symbol("High Cut"), Symbol("DEP SF"), Symbol("CC SF"), :CutError)}
 
     # get worker pool
     wpool = get_workerPool(processing_config, nameof(var"#self#"))
@@ -64,13 +64,13 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
         pol_fit_order               = lq_config_ch.pol_fit_order
         ctc_uncertainty             = lq_config_ch.ctc_uncertainty
 
-        #for lq_cut
-        cut_sigma                   = lq_config_ch.cut_sigma
+        #for lq_norm
         dep_sideband_sigma          = lq_config_ch.dep_sideband_sigma
         cut_truncation_sigma        = lq_config_ch.cut_truncation_sigma
         cut_uncertainty             = lq_config_ch.cut_uncertainty
 
         #for get_peaks_survival_fractions
+        high_cut_sigma              = lq_config_ch.high_cut_sigma
         lq_peaks_names              = Symbol.(lq_config_ch.lq_peaks_names)
         lq_peaks                    = lq_config_ch.lq_peaks
         lq_peaks_windows_left       = lq_config_ch.lq_peaks_windows_left
@@ -131,7 +131,7 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                     std_lq = std(filter(isfinite, lq_e_corr))
                     median_lq = median(filter(isfinite, lq_e_corr))
 
-                    #normalization
+                    # pre normalization
                     cuts_lq = cut_single_peak(lq_e_corr, 0.0, quantile(filter(isfinite, lq_e_corr), 0.99); n_bins=-1)
                     lq_e_corr ./= cuts_lq.max
 
@@ -142,28 +142,64 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                     throw(ErrorException("Error in energy correction and normalization: $e"))
                 end
 
-                @debug "Calibrate $lq_type"
+                @debug "Drift time correction of $lq_type"
                 drift_result, drift_report = nothing, nothing
                 try 
                     drift_result, drift_report = lq_ctc_correction(lq_e_corr, dt_eff, e_cal, dep_µ, dep_σ;
                         ctc_dep_edgesigma, ctc_lq_precut_relative_cut, lq_outlier_sigma, ctc_driftime_cutoff_method, dt_eff_outlier_sigma, lq_e_corr_expression, dt_eff_expression, ctc_dt_eff_low_quantile, ctc_dt_eff_high_quantile, pol_fit_order, uncertainty=ctc_uncertainty)
                 catch e
-                    @error "Error in drift time correction: $e"
-                    throw(ErrorException("Error in drift time correction: $e"))
+                    @error "Error in drift time correction: $(truncate_error(e))"
+                    throw(ErrorException("Error in drift time correction: $(truncate_error(e))"))
                 end
 
-                #create and save plots
+                # create and save plots
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :DEP, title = get_plottitle(filekey, det, "LQ"), figsize = (620,400))
                 savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_ctc_DEP_$lq_type"))
 
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :whole, title = get_plottitle(filekey, det, "LQ"), figsize = (620,400))
                 savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_ctc_$lq_type"))
 
-                #create log entry
+
+                # create lq normalization                
+                lq_ctc = nothing
+                lq_class_expression = nothing
+                result, report = nothing, nothing
+                lq_class = nothing
+                try
+                    lq_class_expression = drift_result.func
+                    lq_ctc = ljl_propfunc(lq_class_expression).(hit_cal)
+
+                    result, report = lq_norm(dep_µ, dep_σ, e_cal, lq_ctc; 
+                    dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
+                    
+                    lq_class = ljl_propfunc(result.func).(hit_cal)
+                catch e
+                    @error "Error in LQ normalization calculation: $(truncate_error(e))"
+                    throw(ErrorException("Error in LQ normalization calculation: $(truncate_error(e))"))
+                end
+
+                # create and save plots
+                p = LegendMakie.lplot(report.fit_report, xlabel = Makie.rich("LQ", Makie.subscript(" ctc")), digits = 3, figsize = (600,450), 
+                    legend_position = :none, title = get_plottitle(filekey, det, "LQ DEP fit", additional_type=string(lq_type)))
+                Makie.axislegend(position = :lt)
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_dep_normalization_$lq_type"))
+
+                p = LegendMakie.lplot(report.temp_hists, 
+                    title = get_plottitle(filekey, det, "LQ sidebands", additional_type=string(lq_type)), 
+                    xlims = (StatsBase.quantile.(Ref(filter(isfinite, lq_ctc),), (0.05, 0.95)))
+                )
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_sidebands_$lq_type"))
+
+                p = LegendMakie.lplot((; e_cal, edges = report.edges, dep_σ = report.dep_σ),
+                    title = get_plottitle(filekey, det, "LQ side bands", additional_type=string(lq_type)))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_sideband_position_$lq_type"))
+
+
+                # create log entry
                 log_info = log_nt_cal(ch, det, ProcessStatus(1), lq_type, ctc_driftime_cutoff_method, drift_result.fit_result.par[1], "-")
 
                 # add results to dict
-                result_dict[lq_type]    = merge(drift_result, (mean_lq = mean_lq, std_lq = std_lq, median_lq = median_lq))
+                result_dict[lq_type]   =  merge(result, (drift_result = drift_result, mean_lq = mean_lq, std_lq = std_lq, median_lq = median_lq))
                 log_info_dict[lq_type]  = log_info
                 processed_dict[lq_type] = true
 
@@ -195,55 +231,26 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
 
                 # get lq classifier and lq classifier expression
                 lq_class = nothing
-                lq_class_expression = nothing
                 try
-                    lq_class_expression = pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func
-                    lq_class = ljl_propfunc(lq_class_expression).(hit_cal)
+                    norm_func = pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func
+                    lq_class = ljl_propfunc(norm_func).(hit_cal)
                 catch e
-                    @error "lq classifier for $det cannot be loaded: $(truncate_error(e))"
-                    throw(LoadError("lq", 154, "lq classifier data for $det from $period-$run cannot be loaded: $(truncate_error(e))"))
-                end
-                
-                #calculate LQ cut parameter value and normalized lq
-                result, report = nothing, nothing
-                lq_norm = nothing
-                try
-                    result, report = lq_cut(dep_µ, dep_σ, e_cal, lq_class; 
-                    cut_sigma, dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
-                    lq_norm = ljl_propfunc(result.lq_norm_func).(hit_cal)
-                catch e
-                    @error "Error in LQ cut calculation: $e"
-                    throw(ErrorException("Error in LQ cut calculation: $e"))
+                    @error "lq classifier for $det from cannot be loaded: $(truncate_error(e))"
+                    throw(LoadError("lq", 154, "lq classifier data for $det from partition $(part) cannot be loaded: $(truncate_error(e))"))
                 end
 
-                #create and save plots
-                p = LegendMakie.lplot(report.fit_report, xlabel = Makie.rich("LQ", Makie.subscript(" ctc")), digits = 3, figsize = (600,450), 
-                    legend_position = :none, title = get_plottitle(filekey, det, "LQ DEP fit", additional_type=string(lq_classifier)))
-                Makie.vlines!(Measurements.value(report.cut), color = LegendMakie.CoaxGreen, label = "Cut Value", linewidth = 4)
-                Makie.axislegend(position = :lt)
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_dep_fit_$lq_classifier"))
-
-                p = LegendMakie.lplot(report.temp_hists, 
-                    title = get_plottitle(filekey, det, "LQ sidebands", additional_type=string(lq_classifier)), 
-                    xlims = (StatsBase.quantile.(Ref(filter(isfinite, lq_class),), (0.05, 0.95)))
-                )
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_sidebands_$lq_classifier"))
-
-                p = LegendMakie.lplot((; e_cal, edges = report.edges, dep_σ = report.dep_σ),
-                    title = get_plottitle(filekey, det, "LQ side bands", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_sideband_window_$lq_classifier"))
-
-                sel = isfinite.(e_cal) #.&& drift_report.dep_left .< e_cal .< drift_report.dep_right
-                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_norm[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
+                # create and save plots
+                sel = isfinite.(e_cal)
+                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_class[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
                     title = get_plottitle(filekey, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" norm")), limits = (0,3000,-5.5,9.5))
-                Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
+                Makie.hlines!([high_cut_sigma], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
                 Makie.axislegend(position = :rb)
                 LegendMakie.add_watermarks!(position = "outer top", final = true)
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_energy_vs_lq_norm_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_classalized_$lq_classifier"))
 
-                p = LegendMakie.lplot((; e_cal, lq_class, cut_value = report.cut), figsize = (750,400),
+                p = LegendMakie.lplot((; e_cal, lq_class, cut_value = high_cut_sigma), figsize = (750,400),
                     title = get_plottitle(filekey, det, "LQ Performance", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_energy_histogram_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_energy_after_$lq_classifier"))
 
                 fig = Makie.Figure()
                 e_unit = Unitful.unit(first(e_cal))
@@ -251,17 +258,17 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                     xlabel = "Energy ($e_unit)", ylabel = "Survival fraction", limits = (0,3000,0,1),
                     title = get_plottitle(filekey, det, "LQ survival", additional_type=string(lq_classifier)))
                 h1 = StatsBase.fit(StatsBase.Histogram, Unitful.ustrip.(e_unit, e_cal), 0:3:3000)
-                h2 = StatsBase.fit(StatsBase.Histogram, Unitful.ustrip.(e_unit, e_cal)[lq_class .> report.cut], 0:3:3000)
+                h2 = StatsBase.fit(StatsBase.Histogram, Unitful.ustrip.(e_unit, e_cal)[lq_class .> high_cut_sigma], 0:3:3000)
                 Makie.lines!(ax, StatsBase.midpoints(first(h1.edges)), h2.weights ./ h1.weights, label = "Cut fraction", linewidth = 1)
                 Makie.axislegend(ax, position = :lt)
                 LegendMakie.add_watermarks!(final = true)
-                savelfig(LegendMakie.lsavefig, fig, l200, filekey, det, Symbol("cut_fraction_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, fig, l200, filekey, det, Symbol("lq_cut_fraction_$lq_classifier"))
                 
                 @debug("Generate Survival Fractions for LQ")
 
                 result_peaks, report_peaks = nothing, nothing
                 try
-                    result_peaks, report_peaks = get_peaks_survival_fractions(lq_class, e_cal, lq_peaks, lq_peaks_names, lq_peaks_windows_left, lq_peaks_windows_right, result.cut; inverted_mode=true, fit_funcs=lq_peaks_fit_funcs)
+                    result_peaks, report_peaks = get_peaks_survival_fractions(lq_class, e_cal, lq_peaks, lq_peaks_names, lq_peaks_windows_left, lq_peaks_windows_right, high_cut_sigma; inverted_mode=true, fit_funcs=lq_peaks_fit_funcs)
                 catch e
                     @error "Error in peak lq survival fraction calculation: $e"
                     throw(ErrorException("Error in peak lq survival fraction calculation: $e"))
@@ -269,14 +276,14 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
 
                 result_qbb, report_qbb = nothing, nothing
                 try
-                    result_qbb, report_qbb = get_continuum_survival_fraction(lq_class, e_cal, qbb_pos, qbb_window, result.cut, inverted_mode=true)
+                    result_qbb, report_qbb = get_continuum_survival_fraction(lq_class, e_cal, qbb_pos, qbb_window, high_cut_sigma, inverted_mode=true)
                 catch e
                     @error "Error in qbb lq survival fraction calculation: $e"
                     throw(ErrorException("Error in qbb lq survival fraction calculation: $e"))
                 end
                 
                 # save results
-                final_result = merge(result, (peaks = result_peaks, qbb = result_qbb))
+                final_result = (cut = high_cut_sigma, peaks = result_peaks, qbb = result_qbb)
 
                 log_info = log_nt_cut((ch, det, ProcessStatus(1), lq_classifier, final_result.cut, final_result.peaks[:Tl208DEP].sf, final_result.qbb.sf, "-"))
 

--- a/processors/process_lq_calibration_cut.jl
+++ b/processors/process_lq_calibration_cut.jl
@@ -278,10 +278,11 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                     throw(ErrorException("Error in qbb lq survival fraction calculation: $e"))
                 end
                 
-                # save results
-                final_result = (cut = high_cut_sigma, peaks = result_peaks, qbb = result_qbb)
 
-                log_info = log_nt_cut((ch, det, ProcessStatus(1), lq_classifier, final_result.cut, final_result.peaks[:Tl208DEP].sf, final_result.qbb.sf, "-"))
+                # save results
+                final_result = (highcut = high_cut_sigma, peaks = result_peaks, qbb = result_qbb)
+
+                log_info = log_nt_cut((ch, det, ProcessStatus(1), lq_classifier, final_result.highcut, final_result.peaks[:Tl208DEP].sf, final_result.qbb.sf, "-"))
 
                 # add results to dict
                 result_dict[lq_classifier] = final_result

--- a/processors/process_lq_calibration_cut.jl
+++ b/processors/process_lq_calibration_cut.jl
@@ -135,7 +135,7 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                     cuts_lq = cut_single_peak(lq_e_corr, 0.0, quantile(filter(isfinite, lq_e_corr), 0.99); n_bins=-1)
                     lq_e_corr ./= cuts_lq.max
 
-                    lq_e_corr_expression = "$(lq_funcs[lq_type]) / $(cuts_lq.max)"
+                    lq_e_corr_expression = "( ( $(lq_funcs[lq_type]) ) / $(cuts_lq.max) )"
                     dt_eff_expression = qdrift_expression
                 catch e
                     @error "Error in energy correction and normalization: $e"
@@ -154,10 +154,10 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
 
                 #create and save plots
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :DEP, title = get_plottitle(filekey, det, "LQ"), figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("drift_time_vs_lq_plot_DEP_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_drift_time_vs_lq_plot_DEP_$lq_type"))
 
                 p = LegendMakie.lplot(drift_report, e_cal, dt_eff, lq_e_corr, :whole, title = get_plottitle(filekey, det, "LQ"), figsize = (620,400))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("drift_time_vs_lq_plot_$lq_type"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_drift_time_vs_lq_plot_$lq_type"))
 
                 #create log entry
                 log_info = log_nt_cal(ch, det, ProcessStatus(1), lq_type, ctc_driftime_cutoff_method, drift_result.fit_result.par[1], "-")
@@ -193,19 +193,24 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
             try
                 @debug "Generate lq cut"
 
-                #get lq classifier
+                # get lq classifier and lq classifier expression
                 lq_class = nothing
+                lq_class_expression = nothing
                 try
-                    lq_class = ljl_propfunc(pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func).(hit_cal)
+                    lq_class_expression = pars_db_ch[det][Symbol(first(split(string(lq_classifier), "_classifier")))].func
+                    lq_class = ljl_propfunc(lq_class_expression).(hit_cal)
                 catch e
                     @error "lq classifier for $det cannot be loaded: $(truncate_error(e))"
                     throw(LoadError("lq", 154, "lq classifier data for $det from $period-$run cannot be loaded: $(truncate_error(e))"))
                 end
                 
-                #calculate LQ cut parameter value
+                #calculate LQ cut parameter value and normalized lq
                 result, report = nothing, nothing
+                lq_norm = nothing
                 try
-                    result, report = lq_cut(dep_µ, dep_σ, e_cal, lq_class; cut_sigma, dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty)
+                    result, report = lq_cut(dep_µ, dep_σ, e_cal, lq_class; 
+                    cut_sigma, dep_sideband_sigma, cut_truncation_sigma, uncertainty=cut_uncertainty, lq_class_expression)
+                    lq_norm = ljl_propfunc(result.lq_norm_func).(hit_cal)
                 catch e
                     @error "Error in LQ cut calculation: $e"
                     throw(ErrorException("Error in LQ cut calculation: $e"))
@@ -213,32 +218,32 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
 
                 #create and save plots
                 p = LegendMakie.lplot(report.fit_report, xlabel = Makie.rich("LQ", Makie.subscript(" ctc")), digits = 3, figsize = (600,450), 
-                    legend_position = :none, title = get_plottitle(filekey, det, "LQ Cut", additional_type=string(lq_classifier)))
+                    legend_position = :none, title = get_plottitle(filekey, det, "LQ DEP fit", additional_type=string(lq_classifier)))
                 Makie.vlines!(Measurements.value(report.cut), color = LegendMakie.CoaxGreen, label = "Cut Value", linewidth = 4)
                 Makie.axislegend(position = :lt)
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_cut_fit_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_dep_fit_$lq_classifier"))
 
                 p = LegendMakie.lplot(report.temp_hists, 
                     title = get_plottitle(filekey, det, "LQ sidebands", additional_type=string(lq_classifier)), 
                     xlims = (StatsBase.quantile.(Ref(filter(isfinite, lq_class),), (0.05, 0.95)))
                 )
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("sideband_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_sidebands_$lq_classifier"))
 
                 p = LegendMakie.lplot((; e_cal, edges = report.edges, dep_σ = report.dep_σ),
                     title = get_plottitle(filekey, det, "LQ side bands", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("energy_spectrum_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_sideband_window_$lq_classifier"))
 
                 sel = isfinite.(e_cal) #.&& drift_report.dep_left .< e_cal .< drift_report.dep_right
-                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_class[sel]), (0:1:3000, range(-3.5, 5.5, length=200))),
-                    title = get_plottitle(filekey, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = ylabel = Makie.rich("LQ", Makie.subscript(" ctc")), limits = (0,3000,-3.5,5.5))
-                Makie.hlines!([Measurements.value(report.cut)], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
-                Makie.axislegend(position = :rb)
+                p = LegendMakie.lhist(StatsBase.fit(StatsBase.Histogram, (Unitful.ustrip.(e_cal)[sel], lq_norm[sel]), (0:1:3000, range(-5.5, 9.5, length=200))),
+                    title = get_plottitle(filekey, det, "LQ"), figsize = (620,400), watermark = false, xlabel = "Energy (keV)", ylabel = Makie.rich("LQ", Makie.subscript(" norm")), limits = (0,3000,-5.5,9.5))
+                #Makie.hlines!([3], color = LegendMakie.CoaxGreen, label = "LQ cut", linewidth = 4)
+                #Makie.axislegend(position = :rb)
                 LegendMakie.add_watermarks!(position = "outer top", final = true)
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_cut_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_energy_vs_lq_norm_$lq_classifier"))
 
                 p = LegendMakie.lplot((; e_cal, lq_class, cut_value = report.cut), figsize = (750,400),
                     title = get_plottitle(filekey, det, "LQ Performance", additional_type=string(lq_classifier)))
-                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("energy_hist_$lq_classifier"))
+                savelfig(LegendMakie.lsavefig, p, l200, filekey, det, Symbol("lq_energy_histogram_$lq_classifier"))
 
                 fig = Makie.Figure()
                 e_unit = Unitful.unit(first(e_cal))
@@ -252,7 +257,7 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
                 LegendMakie.add_watermarks!(final = true)
                 savelfig(LegendMakie.lsavefig, fig, l200, filekey, det, Symbol("cut_fraction_$lq_classifier"))
                 
-                @debug("Generate Surrvival Fractions for LQ")
+                @debug("Generate Survival Fractions for LQ")
 
                 result_peaks, report_peaks = nothing, nothing
                 try


### PR DESCRIPTION
This pull request incorporates the changes made in PR https://github.com/legend-exp/LegendSpecFits.jl/pull/144 .
The `lq_cut` function now recieves as an additional argument the expression of the unnormalized lq classifier. The function then calculates and returns the expression for the normilzed lq vector in its results. 

I also added some brackets(even though not necessary) to the `lq_e_corr_expression` so that the other expression is more clear.

In addition to the changes i also updated the file names used to save plots. Now they all start with `lq` so that all the lq plots are grouped by name together.