### PR TITLE
Ignore ML QC (f_evaluate) for optimization processors and kwarg for DSP cal and phy

### DIFF
--- a/config/processing_config.json
+++ b/config/processing_config.json
@@ -90,7 +90,8 @@
                 "reprocess": false,
                 "max_wvfs": 1000,
                 "timeout": 0,
-                "use_partition_filter": true
+                "use_partition_filter": true,
+                "use_ml_qc": true
             },
             "dependencies": ["p_process_aoe_optimization", "p_process_filter_optimization", "p_process_decay_time"]
         },
@@ -182,7 +183,8 @@
                 "reprocess": true,
                 "timeout": 0,
                 "max_wvfs": 1000,
-                "use_partition_filter": true
+                "use_partition_filter": true,
+                "use_ml_qc": true
             },
             "dependencies": ["p_process_sipm_optimization_phy"]
         },

--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -11,11 +11,6 @@ function p_process_aoe_optimization(processing_config::PropDict, l200::LegendDat
     chinfo = channelinfo(l200, filekey; system=:geds, only_processable=true) |> filterby(@pf $low_aoe_status in [:valid, :present])
     @info "Loaded channel info with $(length(chinfo)) detectors"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
-
     if reprocess @info "Reprocess all detectors" else @info "Only process detectors not in pars_db" end
 
     # create log line Tuple
@@ -155,8 +150,8 @@ function det_sg_optimization(chinfo_det::NamedTuple)
                 try
                     # DSP
                     @debug "Generating DSP AoE grid for SEP and DEP data"
-                    dsp_dep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_dep_wdw, wvfs_det_dep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc, presum_rate=presum_rate)
-                    dsp_sep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_sep_wdw, wvfs_det_sep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc, presum_rate=presum_rate)
+                    dsp_dep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_dep_wdw, wvfs_det_dep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; presum_rate=presum_rate)
+                    dsp_sep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_sep_wdw, wvfs_det_sep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; presum_rate=presum_rate)
                 catch e
                     @error "Failed DSP for DEP or SEP: $(truncate_error(e))"
                     throw(ErrorException("Error in DSP for DEP or SEP: $(truncate_error(e))"))

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -10,11 +10,6 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
     chinfo = channelinfo(l200, filekey; system=:geds, only_processable=true)
     @info "Loaded channel info with $(length(chinfo)) detectors"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
-
     # create log line Tuple
     log_nt = NamedTuple{(:Detector, :Channel, :Partition, :Status, Symbol("Decay Time"), Symbol("σ"), :Error)}
     
@@ -103,7 +98,7 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         # get QC cuts
         try
             @debug "Get QC cuts"
-            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det, dsp_config_det, 400.0u"µs", f_evaluate_qc)
+            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det, dsp_config_det, 400.0u"µs")
             qc = ljl_propfunc(qc_string).(dsp_qc)
             wvfs_det = wvfs_det[findall(qc)]
             @debug "Survival Fraction: $(round(count(qc) / length(qc) * 100, digits=2))%"

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -11,11 +11,6 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
     chinfo = channelinfo(l200, filekey; system=:geds, only_processable=true)
     @info "Loaded channel info with $(length(chinfo)) detectors"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
-
     if reprocess @info "Reprocess all detectors" else @info "Only process detectors not in pars_db" end
 
     # create log line Tuple
@@ -133,7 +128,7 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
         blmean_wdw = nothing
         try
             @debug "Get QC cuts"
-            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det_pre, dsp_config_det, pars_tau[det].τ, f_evaluate_qc)
+            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det_pre, dsp_config_det, pars_tau[det].τ)
             qc = ljl_propfunc(qc_string).(dsp_qc)
             blmean_wdw = dsp_qc.blmean ./ presum_rate
             wvfs_det_pre = wvfs_det_pre[findall(qc)]

--- a/processors/process_aoe_optimization.jl
+++ b/processors/process_aoe_optimization.jl
@@ -11,11 +11,6 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
     dsp_config_pd = dataprod_config(l200).dsp(filekey)
     @debug "Loaded DSP config: $(dsp_config_pd)"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
-
     pars_tau = get_values(l200.par.rpars.pz[period, run])
     @debug "Loaded decay times"
 
@@ -119,8 +114,8 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
                 try
                     # DSP
                     @debug "Generating DSP AoE grid for SEP and DEP data"
-                    dsp_dep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_dep_wdw, wvfs_det_dep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc, presum_rate=presum_rate)
-                    dsp_sep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_sep_wdw, wvfs_det_sep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc, presum_rate=presum_rate)
+                    dsp_dep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_dep_wdw, wvfs_det_dep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; presum_rate=presum_rate)
+                    dsp_sep = getfield(LegendDSP, Symbol("dsp_$(filter_type)_optimization_compressed"))(wvfs_det_sep_wdw, wvfs_det_sep_pre, dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; presum_rate=presum_rate)
                 catch e
                     @error "Failed DSP for DEP or SEP: $(truncate_error(e))"
                     throw(ErrorException("Error in DSP for DEP or SEP: $(truncate_error(e))"))

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -21,11 +21,6 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
     pars_db = ifelse(reprocess, PropDict(), pars_db)
     if reprocess @info "Reprocess all detectors" end
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
-
     # create log line Tuple
     log_nt = NamedTuple{(:Detector, :Channel, :Status, Symbol("Decay Time"), Symbol("σ"), :Error)}
     
@@ -89,7 +84,7 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
         # get QC cuts
         try
             @debug "Get QC cuts"
-            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det, dsp_config_det, 400.0u"µs", f_evaluate_qc)
+            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det, dsp_config_det, 400.0u"µs")
             qc = ljl_propfunc(qc_string).(dsp_qc)
             wvfs_det = wvfs_det[findall(qc)]
             @debug "Survival Fraction: $(round(count(qc) / length(qc) * 100, digits=2))%"

--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -1,4 +1,4 @@
-function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool = false, timeout::Int=0, max_wvfs::Int=10000, use_partition_filter::Bool=true)
+function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool = false, timeout::Int=0, max_wvfs::Int=10000, use_partition_filter::Bool=true, use_ml_qc::Bool=true)
     
     @info "Process DSP for period $period and run $run"
 
@@ -13,10 +13,18 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
     dsp_config_pd = dataprod_config(l200).dsp(filekey)
     @debug "Loaded DSP config: $(dsp_config_pd)"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
+    f_evaluate_qc = if use_ml_qc
+        h5open(get_mltrainfilename(l200, filekey)) do train_data
             get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
         end
-    @info "Loaded trained SVM model"
+    else
+        missing
+    end
+    if use_ml_qc
+        @info "Loaded trained SVM model"
+    else
+        @info "ML QC disabled, skipping SVM model"
+    end
 
     pars_type = ifelse(use_partition_filter, :ppars, :rpars)
     @info "Use $(ifelse(use_partition_filter, "partition", "run"))-based pars from $pars_type for DSP optimization parameters"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -1,4 +1,4 @@
-function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool = false, timeout::Int=0, max_wvfs::Int=10000, use_partition_filter::Bool=false)
+function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool = false, timeout::Int=0, max_wvfs::Int=10000, use_partition_filter::Bool=false, use_ml_qc::Bool=true)
     
     @info "Process DSP for period $period and run $run"
 
@@ -19,10 +19,18 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
     dsp_meta_pmt = dataprod_config(l200).pmt(filekey)
     @debug "Loaded PMT DSP config: $(dsp_meta_pmt)"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
+    f_evaluate_qc = if use_ml_qc
+        h5open(get_mltrainfilename(l200, filekey)) do train_data
             get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
         end
-    @info "Loaded trained SVM model"
+    else
+        missing
+    end
+    if use_ml_qc
+        @info "Loaded trained SVM model"
+    else
+        @info "ML QC disabled, skipping SVM model"
+    end
 
     pars_type = ifelse(use_partition_filter, :ppars, :rpars)
     @info "Use $(ifelse(use_partition_filter, "partition", "run"))-based pars from $pars_type for DSP optimization parameters"

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -24,11 +24,6 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
     pars_db = ifelse(reprocess, PropDict(), pars_db)
     if reprocess @info "Reprocess all detectors" else @info "Only process detectors not in pars_db" end
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
-
     # create log line Tuple
     log_nt = NamedTuple{(:Detector, :Channel, :Status, Symbol("Filter Type"), Symbol("Rise Time"), Symbol("Flat-Top Time"), Symbol("Min. FWHM"), :Error)}
     
@@ -111,7 +106,7 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
         blmean_wdw = nothing
         try
             @debug "Get QC cuts"
-            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det_pre, dsp_config_det, pars_tau[det].τ, f_evaluate_qc)
+            dsp_qc = dsp_qc_flt_optimization_compressed(wvfs_det_pre, dsp_config_det, pars_tau[det].τ)
             qc = ljl_propfunc(qc_string).(dsp_qc)
             blmean_wdw = dsp_qc.blmean ./ presum_rate
             wvfs_det_pre = wvfs_det_pre[findall(qc)]


### PR DESCRIPTION
Enable kwarg in DSP cal/phy if ML QC should be applied in icpc_compressed (DSP). Classical QC are used from config unchanged.