### PR TITLE
Add fallback for missing ML QC model

### DIFF
--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -11,10 +11,7 @@ function p_process_aoe_optimization(processing_config::PropDict, l200::LegendDat
     chinfo = channelinfo(l200, filekey; system=:geds, only_processable=true) |> filterby(@pf $low_aoe_status in [:valid, :present])
     @info "Loaded channel info with $(length(chinfo)) detectors"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     if reprocess @info "Reprocess all detectors" else @info "Only process detectors not in pars_db" end
 

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -10,10 +10,7 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
     chinfo = channelinfo(l200, filekey; system=:geds, only_processable=true)
     @info "Loaded channel info with $(length(chinfo)) detectors"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     # create log line Tuple
     log_nt = NamedTuple{(:Detector, :Channel, :Partition, :Status, Symbol("Decay Time"), Symbol("σ"), :Error)}

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -11,10 +11,7 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
     chinfo = channelinfo(l200, filekey; system=:geds, only_processable=true)
     @info "Loaded channel info with $(length(chinfo)) detectors"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     if reprocess @info "Reprocess all detectors" else @info "Only process detectors not in pars_db" end
 

--- a/processors/process_aoe_optimization.jl
+++ b/processors/process_aoe_optimization.jl
@@ -11,10 +11,7 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
     dsp_config_pd = dataprod_config(l200).dsp(filekey)
     @debug "Loaded DSP config: $(dsp_config_pd)"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     pars_tau = get_values(l200.par.rpars.pz[period, run])
     @debug "Loaded decay times"

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -21,10 +21,7 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
     pars_db = ifelse(reprocess, PropDict(), pars_db)
     if reprocess @info "Reprocess all detectors" end
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     # create log line Tuple
     log_nt = NamedTuple{(:Detector, :Channel, :Status, Symbol("Decay Time"), Symbol("σ"), :Error)}

--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -13,10 +13,7 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
     dsp_config_pd = dataprod_config(l200).dsp(filekey)
     @debug "Loaded DSP config: $(dsp_config_pd)"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     pars_type = ifelse(use_partition_filter, :ppars, :rpars)
     @info "Use $(ifelse(use_partition_filter, "partition", "run"))-based pars from $pars_type for DSP optimization parameters"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -19,10 +19,7 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
     dsp_meta_pmt = dataprod_config(l200).pmt(filekey)
     @debug "Loaded PMT DSP config: $(dsp_meta_pmt)"
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     pars_type = ifelse(use_partition_filter, :ppars, :rpars)
     @info "Use $(ifelse(use_partition_filter, "partition", "run"))-based pars from $pars_type for DSP optimization parameters"

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -24,10 +24,7 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
     pars_db = ifelse(reprocess, PropDict(), pars_db)
     if reprocess @info "Reprocess all detectors" else @info "Only process detectors not in pars_db" end
 
-    f_evaluate_qc = h5open(get_mltrainfilename(l200, filekey)) do train_data
-            get_qc_ml_func(Array(train_data["ml_train/dsp/dwt_norm"]), Array(train_data["ml_train/dsp/dc_label"]), l200.par.rpars.ml(filekey))
-        end
-    @info "Loaded trained SVM model"
+    f_evaluate_qc = load_qc_evaluator(l200, filekey)
 
     # create log line Tuple
     log_nt = NamedTuple{(:Detector, :Channel, :Status, Symbol("Filter Type"), Symbol("Rise Time"), Symbol("Flat-Top Time"), Symbol("Min. FWHM"), :Error)}

--- a/src/config.jl
+++ b/src/config.jl
@@ -294,3 +294,37 @@ function setup_dependency_graph(l200::LegendData, processing_config::PropDict, p
 
     return process_status, p_process_status
 end
+
+
+"""
+    load_qc_evaluator(l200::LegendData, filekey::FileKey)
+
+Load the ML QC evaluator function if available.
+
+If no trained model file is found, or if loading the model fails,
+returns `missing`. Downstream DSP code skips Haar wavelet classification
+when the evaluator is `missing` and defaults `qc_label` to `-1`.
+"""
+function load_qc_evaluator(l200::LegendData, filekey::FileKey)
+    ml_filename = get_mltrainfilename(l200, filekey)
+    
+    if isfile(ml_filename)
+        try
+            f_evaluate_qc = h5open(ml_filename) do train_data
+                get_qc_ml_func(
+                    Array(train_data["ml_train/dsp/dwt_norm"]), 
+                    Array(train_data["ml_train/dsp/dc_label"]), 
+                    l200.par.rpars.ml(filekey)
+                )
+            end
+            @info "Loaded trained SVM model from $(basename(ml_filename))"
+            return f_evaluate_qc
+        catch e
+            @warn "Failed to load ML model from $(ml_filename): $e"
+        end
+    else
+        @info "ML training file not found: $(basename(ml_filename)) - skipping ML QC"
+    end
+    
+    return missing
+end

--- a/src/config.jl
+++ b/src/config.jl
@@ -309,22 +309,17 @@ function load_qc_evaluator(l200::LegendData, filekey::FileKey)
     ml_filename = get_mltrainfilename(l200, filekey)
     
     if isfile(ml_filename)
-        try
-            f_evaluate_qc = h5open(ml_filename) do train_data
-                get_qc_ml_func(
-                    Array(train_data["ml_train/dsp/dwt_norm"]), 
-                    Array(train_data["ml_train/dsp/dc_label"]), 
-                    l200.par.rpars.ml(filekey)
-                )
-            end
-            @info "Loaded trained SVM model from $(basename(ml_filename))"
-            return f_evaluate_qc
-        catch e
-            @warn "Failed to load ML model from $(ml_filename): $e"
+        f_evaluate_qc = h5open(ml_filename) do train_data
+            get_qc_ml_func(
+                Array(train_data["ml_train/dsp/dwt_norm"]), 
+                Array(train_data["ml_train/dsp/dc_label"]), 
+                l200.par.rpars.ml(filekey)
+            )
         end
+        @info "Loaded trained SVM model from $(basename(ml_filename))"
+        return f_evaluate_qc
     else
         @info "ML training file not found: $(basename(ml_filename)) - skipping ML QC"
+        return missing
     end
-    
-    return missing
 end


### PR DESCRIPTION
Introduces load_qc_evaluator() in src/config.jl and updates 8 DSP/optimization processors to use it. Previously, processors crashed with an unhandled error when the ML training file was absent. Now, if the model file is missing or fails to load, the function returns missing — which skips the expensive Haar wavelet filtering in get_qc_classifier entirely. 