### PR TITLE
Fix partitioninfo calls in DSP processors

### DIFF
--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -32,9 +32,9 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
         ch = chinfo_det.channel
         det = chinfo_det.detector
         # prevent DSP from failing if run doesnt appear in any partition by using pars from partition of closest run
-        if use_partition_filter && !haskey(pars_tau, det) && !haskey(pars_fltoptimization, det) && chinfo_det.processable != :on && isempty(partitioninfo(l200, ch, period, run))
+        if use_partition_filter && !haskey(pars_tau, det) && !haskey(pars_fltoptimization, det) && chinfo_det.processable != :on && isempty(partitioninfo(l200, det, :cal, period, run))
             @warn "Detector $det ($ch) doesn't have pars and optimization parameters since $period/$run is not in any `DataPartition` for detector"
-            parts = partitioninfo(l200, det, period)
+            parts = partitioninfo(l200, det, :cal, period)
             closest_runs_distance = Real[]
             for p in parts
                 pinfo = filter(row -> row.period == period, partitioninfo(l200, det, p))

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -38,12 +38,12 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
         ch = chinfo_det.channel
         det = chinfo_det.detector
         # prevent DSP from failing if run doesnt appear in any partition by using pars from partition of closest run
-        if use_partition_filter && !haskey(pars_tau, det) && !haskey(pars_fltoptimization, det) && chinfo_det.processable != :on && isempty(partitioninfo(l200, ch, period, run))
+        if use_partition_filter && !haskey(pars_tau, det) && !haskey(pars_fltoptimization, det) && chinfo_det.processable != :on && isempty(partitioninfo(l200, det, :cal, period, run))
             @warn "Detector $det ($ch) doesn't have pars and optimization parameters since $period/$run is not in any `DataPartition` for detector"
-            parts = partitioninfo(l200, ch, period)
+            parts = partitioninfo(l200, det, :cal, period)
             closest_runs_distance = Real[]
             for p in parts
-                pinfo = filter(row -> row.period == period, partitioninfo(l200, ch, p))
+                pinfo = filter(row -> row.period == period, partitioninfo(l200, det, p))
                 closest_run = pinfo.run[argmin([abs(r.no - run.no) for r in pinfo.run])]
                 push!(closest_runs_distance, abs(closest_run.no - run.no))
             end


### PR DESCRIPTION
Fixes incorrect partitioninfo calls in process_dsp_cal.jl and process_dsp_phy.jl. The previous calls did not use DetectorId wrapping and were missing the explicit :cal category argument, which caused partition lookup failures for detectors with non-standard naming.