### PR TITLE
Filter bad filekeys in hit calibration processor

### DIFF
--- a/processors/p_process_lq_calibration_cut.jl
+++ b/processors/p_process_lq_calibration_cut.jl
@@ -56,7 +56,7 @@ function p_process_lq_calibration_cut(processing_config::PropDict, l200::LegendD
         # load lq config
         lq_config = dataprod_config(l200).psd(filekey_det).lq
         lq_config_det = merge(lq_config.p_default, get(lq_config.p, det, PropDict()))
-        @debug "Loaded aoe config: $(lq_config_det)"
+        @debug "Loaded lq config: $(lq_config_det)"
 
         e_type                      = Symbol(lq_config_det.e_type)
         lq_types                    = collect(keys(lq_config_det.lq_funcs))

--- a/processors/p_process_sipm_optimization_phy.jl
+++ b/processors/p_process_sipm_optimization_phy.jl
@@ -43,6 +43,8 @@ function p_process_sipm_optimization_phy(processing_config::PropDict, l200::Lege
 
         partinfo_det = partitioninfo(l200, det, part)
         @debug "Loaded detector partition info with $(length(partinfo_det)) runs"
+
+        filekeys = reduce(vcat, [filter(!in(bad_filekeys(l200; load_key=:unprocessable)), search_disk(FileKey, l200.tier[:raw, :phy, r.period, r.run])) for r in partinfo_det])
     
         filekey_det = first(getproperty(partinfo_det, :phy)).startkey
         @debug "Found filekey $filekey_det"
@@ -102,7 +104,7 @@ function p_process_sipm_optimization_phy(processing_config::PropDict, l200::Lege
         # load data
         data_det = nothing
         try
-            data_det = read_ldata((:waveform_bit_drop, :timestamp), l200, DataTier(:raw), :phy, partinfo_det, det; n_evts=optimization_config_det.n_evts)
+            data_det = read_ldata((:waveform_bit_drop, :timestamp), l200, DataTier(:raw), filekeys, det; n_evts=optimization_config_det.n_evts)
             @debug "Loading SiPM data from $(part)"
             if length(data_det) > max_wvfs
                 @warn "SiPM events exceed $max_wvfs, keep only $max_wvfs events"

--- a/processors/p_process_skm_phy.jl
+++ b/processors/p_process_skm_phy.jl
@@ -29,7 +29,7 @@ function p_process_skm_phy(processing_config::PropDict, l200::LegendData, period
         r = fk.run
         p = fk.period
 
-        filekeys = filter(!in(bad_filekeys(l200)), search_disk(FileKey, l200.tier[:jlevt, :phy, p, r]))
+        filekeys = filter(!in(bad_filekeys(l200; load_key=:all)), search_disk(FileKey, l200.tier[:jlevt, :phy, p, r]))
         @info "Found $(length(filekeys)) filekeys for run $r in period $p"
 
         @info "Processing run $r in period $p"

--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -2,7 +2,7 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
     
     @info "Process DSP for period $period and run $run"
 
-    filekeys = search_disk(FileKey, l200.tier[:raw, :cal, period, run])
+    filekeys = filter(!in(bad_filekeys(l200; load_key=:unprocessable)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
     
     filekey = start_filekey(l200, (period, run, :cal))
     @info "Found start filekey $filekey"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -2,7 +2,7 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
     
     @info "Process DSP for period $period and run $run"
 
-    filekeys = search_disk(FileKey, l200.tier[:raw, :phy, period, run])
+    filekeys = filter(!in(bad_filekeys(l200; load_key=:unprocessable)), search_disk(FileKey, l200.tier[:raw, :phy, period, run]))
     
     filekey = start_filekey(l200, (period, run, :phy))
     @info "Found start filekey $filekey"

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -2,7 +2,8 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
 
     @info "Generate cal hit for period $period and run $run"
 
-    filekeys = search_disk(FileKey, l200.tier[:jldsp, :cal, period, run])
+    filekeys = filter(!in(bad_filekeys(l200; load_key=:removed)), search_disk(FileKey, l200.tier[:jldsp, :cal, period, run]))
+    raw_filekeys = filter(!in(bad_filekeys(l200)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
     
     filekey = start_filekey(l200, (period, run, :cal))
     @info "Found filekey $filekey"
@@ -46,9 +47,9 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         if !reprocess && isfile(pulserfilename)
             return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(lh5open(pulserfilename)[det_puls, :jlpls, :tags]), "Already processed --> skipped.")))
         end
-        # extract pulser events by loading data from raw files
+        # extract pulser events by loading data from raw files (filtered by bad_filekeys)
         @info "Get pulser events from raw data"
-        data_puls = read_ldata((:daqenergy, :timestamp), l200, DataTier(:raw), DataCategory(:cal), period, run, det_puls)
+        data_puls = read_ldata((:daqenergy, :timestamp), l200, DataTier(:raw), raw_filekeys, det_puls)
         
         @info "Write Pulser events to disk"
         write_files(pulserfilename, use_cache=true, mode = CreateOrReplace()) do outfilename

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -2,7 +2,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
 
     @info "Generate cal hit for period $period and run $run"
 
-    filekeys = filter(!in(bad_filekeys(l200; load_key=:removed)), search_disk(FileKey, l200.tier[:jldsp, :cal, period, run]))
+    filekeys = filter(!in(bad_filekeys(l200; load_key=:all)), search_disk(FileKey, l200.tier[:jldsp, :cal, period, run]))
     raw_filekeys = filter(!in(bad_filekeys(l200; load_key=:unprocessable)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
     
     filekey = start_filekey(l200, (period, run, :cal))

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -3,7 +3,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
     @info "Generate cal hit for period $period and run $run"
 
     filekeys = filter(!in(bad_filekeys(l200; load_key=:removed)), search_disk(FileKey, l200.tier[:jldsp, :cal, period, run]))
-    raw_filekeys = filter(!in(bad_filekeys(l200; load_key=:all)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
+    raw_filekeys = filter(!in(bad_filekeys(l200; load_key=:unprocessable)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
     
     filekey = start_filekey(l200, (period, run, :cal))
     @info "Found filekey $filekey"

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -3,7 +3,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
     @info "Generate cal hit for period $period and run $run"
 
     filekeys = filter(!in(bad_filekeys(l200; load_key=:removed)), search_disk(FileKey, l200.tier[:jldsp, :cal, period, run]))
-    raw_filekeys = filter(!in(bad_filekeys(l200)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
+    raw_filekeys = filter(!in(bad_filekeys(l200; load_key=:all)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
     
     filekey = start_filekey(l200, (period, run, :cal))
     @info "Found filekey $filekey"

--- a/processors/process_peak_split.jl
+++ b/processors/process_peak_split.jl
@@ -59,7 +59,7 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
         filekeys = read_filekeys(keylist_filename)
         files_checked = true
     else
-        filekeys = search_disk(FileKey, l200.tier[:raw, :cal, period, run])
+        filekeys = filter(!in(bad_filekeys(l200)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
         files_checked = false
     end
     isempty(filekeys) && error("No files found in \"$input_datadir\"")

--- a/processors/process_peak_split.jl
+++ b/processors/process_peak_split.jl
@@ -59,7 +59,7 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
         filekeys = read_filekeys(keylist_filename)
         files_checked = true
     else
-        filekeys = filter(!in(bad_filekeys(l200)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
+        filekeys = filter(!in(bad_filekeys(l200; load_key=:all)), search_disk(FileKey, l200.tier[:raw, :cal, period, run]))
         files_checked = false
     end
     isempty(filekeys) && error("No files found in \"$input_datadir\"")

--- a/processors/process_sipm_optimization_phy.jl
+++ b/processors/process_sipm_optimization_phy.jl
@@ -2,6 +2,8 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         
     @info "Process SiPM optimization for period $period and run $run"
 
+    filekeys = filter(!in(bad_filekeys(l200; load_key=:unprocessable)), search_disk(FileKey, l200.tier[:raw, :phy, period, run]))
+
     filekey = start_filekey(l200, (period, run, :phy))
     @info "Found filekey $filekey"
 
@@ -52,7 +54,7 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         end
         # extract pulser events by loading data from raw files
         @info "Get pulser events from raw data"
-        raw_pls = read_ldata(l200, DataTier(:raw), :phy, period, run, det_puls)
+        raw_pls = read_ldata(l200, DataTier(:raw), filekeys, det_puls)
         
         dsp_config_pd = dataprod_config(l200).dsp(filekey)
         dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det_puls, PropDict()))
@@ -131,7 +133,7 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         # load data
         data_det = nothing
         try
-            data_det = read_ldata((:waveform_bit_drop, :timestamp), l200, DataTier(:raw), :phy, period, run, det)
+            data_det = read_ldata((:waveform_bit_drop, :timestamp), l200, DataTier(:raw), filekeys, det)
             @debug "Loading SiPM data from $(period)-$(run)"
             if length(data_det) > max_wvfs
                 @warn "SiPM events exceed $max_wvfs, keep only $max_wvfs events"


### PR DESCRIPTION
Filters out known-bad filekeys (via bad_filekeys(l200)) from both DSP and raw file lists before processing the DSP tier. The raw filekey list is passed directly to read_ldata for pulser extraction to ensure consistency between DSP and raw data selection. The DSP is running with all files to see the failed files, to be able to compare failed files with unprocessable or removed in `legend-metadata/datasets/ignored_daq_cycles.yaml`. For the hit processing (QC on DSP) we read over all files in run für each detector which caused a crash for a failed file in the DSP 