### PR TITLE
Migrate processors to read_ldata and unify per-detector tier layout

### DIFF
--- a/docs/src/tier_structure.md
+++ b/docs/src/tier_structure.md
@@ -1,0 +1,541 @@
+# LEGEND L200 Tier File Structure
+
+Reference for the on-disk HDF5 layout of the LEGEND L200 tier files: the FlashCam `raw`
+output and the Julia-side `jldsp`, `jlhit`, `jlevt`, `jlpmt`, and `jlpls` tiers. Every
+tier is stored in [LH5](https://github.com/legend-exp/legend-pydataobj) format (HDF5
+with `@datatype` attributes describing nested structs, tables and variable-length
+arrays).
+
+This document describes the **general** structure that applies to every period and run.
+The exact set of detectors, channel counts, and per-event sizes change run-by-run, but
+the schema and grouping conventions do not.
+
+---
+
+## 1. Filekey conventions and tier availability
+
+A *filekey* identifies one acquisition window and has the form
+`l200-p<P>-r<R>-<cat>-<TS>` where `<TS>` is a UTC timestamp like `20251107T191821Z` and
+`<cat>` is the data category (`cal` for calibration, `phy` for physics).
+
+| Tier   | `cal` | `phy` | One file represents …                  | Filename pattern |
+|--------|:-----:|:-----:|----------------------------------------|------------------|
+| raw    |   ✓   |   ✓   | one filekey (timestamp window)         | `l200-p<P>-r<R>-<cat>-<TS>-tier_raw.lh5` |
+| jldsp  |   ✓   |   ✓   | one filekey                            | `l200-p<P>-r<R>-<cat>-<TS>-tier_jldsp.lh5` |
+| jlhit  |   ✓   |   —   | one detector for the entire run        | `l200-p<P>-r<R>-cal-<DETID>-tier_jlhit.lh5` |
+| jlevt  |   —   |   ✓   | one filekey                            | `l200-p<P>-r<R>-phy-<TS>-tier_jlevt.lh5` |
+| jlpmt  |   —   |   ✓   | one filekey                            | `l200-p<P>-r<R>-phy-<TS>-tier_jlpmt.lh5` |
+| jlpls  |   ✓   |   ✓   | one pulser channel for the entire run  | `l200-p<P>-r<R>-<cat>-<PULSID>-tier_jlpls.lh5` |
+
+Notes:
+
+- `jlhit` exists only for `cal`. `jlevt` and `jlpmt` exist only for `phy`. `jldsp`
+  and `jlpls` exist for both categories.
+- For `jlpls` the pulser ID is `PULS01` in `cal` and `PULS01ANA` in `phy`.
+
+### Detector naming conventions
+
+| Prefix   | System                        | Examples                         |
+|----------|-------------------------------|----------------------------------|
+| `V…`     | HPGe inverted-coax            | `V00048A`, `V14654A`             |
+| `B…`     | HPGe BEGe                     | `B00000C`, `B00000D`             |
+| `PMT…`   | muon-veto PMTs                | `PMT101`–`PMT710`                |
+| `S…`     | LAr-veto SiPMs                | `S002`–`S100`                    |
+| `BSLN01` | dedicated baseline trigger    | (single channel)                 |
+| `PULS01` | pulser, raw                   | (single channel)                 |
+| `PULS01ANA` | pulser, analyzed (phy only)| (single channel)                 |
+| `MUON01` | muon-veto sum (phy only)      | (single channel)                 |
+| `BF862-…`| FET test channels (phy only)  | only listed in the `/raw` view of the raw file |
+| `chXXXXXXX` | FlashCam stream IDs        | independent auxiliary streams (see §2) |
+
+> The `chXXXXXXX` top-level keys are **not** aliases of `V*`/`B*`/`PMT*`/`S*`
+> detectors. They are independent FlashCam streams that run in parallel and carry
+> different timestamps and `board_id` values.
+
+---
+
+## 2. `raw` tier (FlashCam DAQ output)
+
+### 2.1 Top-level layout
+
+```
+/                                File root (no @datatype on the root itself)
+├── <DETID>/                     e.g. /V00048A
+│   └── raw/                     (table) — see §2.2
+│       ├── <scalar columns>
+│       ├── waveform_presummed/  GED only
+│       ├── waveform_windowed/   GED only
+│       ├── waveform/            PMT only
+│       └── waveform_bit_drop/   SPM only
+├── chXXXXXXX/                   independent FlashCam streams
+│   └── raw/...                  (same shape)
+├── extra/                       DAQ metadata
+│   ├── OrcaHeader               :: Cstring
+│   ├── RunControl/              run_number, time, runstartorstop, …
+│   ├── fcid_1/                  config, status
+│   └── fcid_2/                  config, status
+└── raw/                         struct view: every detector as a sub-key
+    ├── <DETID>                  hard/soft link to /<DETID>/raw
+    └── …
+```
+
+`/<DETID>/raw/...` and `/raw/<DETID>/...` resolve to the **same** dataset (a soft-link
+view); the per-detector path is the canonical one.
+
+The phy raw file additionally exposes `MUON01`, `PULS01ANA`, and `BF862-XX` only in the
+`/raw/` struct view (i.e. they are listed under `/raw/<name>` but not as a separate
+top-level group).
+
+### 2.2 `<DETID>/raw/` columns
+
+Every detector's `raw/` group is a `table{...}` with about 33 scalar columns plus one
+or more waveform sub-groups.
+
+#### Scalar columns common to all systems
+
+| Column              | Type     | Description |
+|---------------------|----------|-------------|
+| `abs_delta_mu_usec` | Int32    | \|`delta_mu_usec`\| |
+| `baseline`          | UInt16   | FPGA baseline estimate |
+| `board_id`          | UInt16   | FlashCam board MAC |
+| `channel`           | UInt16   | per-stream channel index |
+| `daqenergy`         | UInt16   | trigger energy estimator (62.5 MHz: pulse height; 250 MHz: integral over `sumlength`) |
+| `deadinterval_nsec` | Int64    | dead interval before this event (4 ns precision) |
+| `deadtime`          | Float64  | accumulated dead time per channel |
+| `delta_mu_usec`     | Int32    | FPGA↔server clock offset |
+| `dr_ch_idx`         | UInt16   | start channel of the dead range |
+| `dr_ch_len`         | UInt16   | length of the dead range |
+| `dr_maxticks`       | Int32    | tick value at PPS when buffers became free |
+| `dr_start_pps`      | Int32    | PPS counter at buffer-full |
+| `dr_start_ticks`    | Int32    | tick counter at buffer-full |
+| `dr_stop_pps`       | Int32    | PPS counter at buffer-free |
+| `dr_stop_ticks`     | Int32    | tick counter at buffer-free |
+| `event_type`        | Int32    | 1 = shared trigger, 11 = sparse mode |
+| `eventnumber`       | Int32    | trigger counter |
+| `fc_input`          | UInt16   | per-board ADC channel |
+| `fcid`              | UInt16   | stream ID |
+| `lifetime`          | Float64  | accumulated live time |
+| `mu_offset_sec`     | Int32    | server↔FPGA seconds |
+| `mu_offset_usec`    | Int32    | server↔FPGA microseconds |
+| `numtraces`         | Int32    | |
+| `packet_id`         | UInt32   | decoded packet index |
+| `runtime`           | Float64  | time since run start (per channel) |
+| `timestamp`         | Float64  | unix time |
+| `to_master_sec`     | Int32    | offset server↔FPGA (gps mode) |
+| `to_start_sec`      | Int32    | run-start seconds |
+| `to_start_usec`     | Int32    | run-start microseconds |
+| `ts_maxticks`       | Int32    | tick counter at last PPS |
+| `ts_pps`            | Int32    | PPS counter |
+| `ts_ticks`          | Int32    | 250 MHz tick counter |
+
+#### Additional columns on GED systems (`V*`, `B*`, `BSLN01`, `PULS01`, `MUON01`)
+
+| Column         | Type   |
+|----------------|--------|
+| `presum_rate`  | UInt16 (`Float32` on `BSLN01`) |
+| `t_sat_hi`     | UInt16 (`Float32` on `BSLN01`) |
+| `t_sat_lo`     | UInt16 (`Float32` on `BSLN01`) |
+
+GED detectors therefore have 37 scalar columns; PMTs and SPMs have 33.
+
+#### Waveform sub-groups
+
+| System    | Sub-group(s)                                    | Encoding |
+|-----------|-------------------------------------------------|----------|
+| GED       | `waveform_presummed/`, `waveform_windowed/`     | `uleb128_zigzag_diff` (encoded) |
+| PMT       | `waveform/`                                     | unencoded `UInt16` (samples × events) |
+| SPM       | `waveform_bit_drop/`                            | `uleb128_zigzag_diff` (encoded) |
+
+Each waveform sub-group has the layout `table{dt, t0, values}`:
+
+```
+waveform_<variant>/
+├── dt :: Float32 (n_events,)        sample spacing
+├── t0 :: Float32 (n_events,)        start time
+└── values
+    ├── (encoded)         Group { codec = "uleb128_zigzag_diff",
+    │                              decoded_size :: Int64,
+    │                              encoded_data :: VoV }
+    └── (unencoded, PMT)  Dataset UInt16 (samples_per_wf, n_events)
+```
+
+### 2.3 `extra/` — DAQ metadata
+
+| Path                       | Type    | Content |
+|----------------------------|---------|---------|
+| `extra/OrcaHeader`         | Cstring | full ORCA header XML/JSON |
+| `extra/RunControl/`        | Group   | sub-keys `run_number`, `time`, `runstartorstop`, `endsubrunrecord`, `heartbeatrecord`, `quickstartrun`, `remotecontrolrun`, `startsubrunrecord`, `subrun_number` |
+| `extra/fcid_1/`, `fcid_2/` | Group   | per-stream `config` and `status` sub-groups |
+
+---
+
+## 3. `jldsp` tier (DSP output, all detectors per filekey)
+
+### 3.1 Layout
+
+```
+/
+└── jldsp/                       Group
+    ├── <DETID>/                 (table)
+    │   └── <DSP scalar columns>
+    └── …
+```
+
+One file holds one filekey; every detector that produced data in that filekey appears
+as a sub-group of `/jldsp/`.
+
+- `cal` files contain only GED detectors at this level.
+- `phy` files additionally contain SiPMs (`S*`), `MUON01`, and `PULS01`.
+
+### 3.2 GED schema (`V*`, `B*`) — 72 scalar columns
+
+Every column is a vector of length `n_triggers_for_this_det_in_this_filekey`.
+
+| Group           | Columns |
+|-----------------|---------|
+| time            | `timestamp :: Float64`, `deadtime :: Float64` |
+| id              | `eventID_fadc :: Int32` |
+| DAQ pass-through| `e_fc :: UInt16`, `blfc :: UInt16` |
+| saturation      | `n_sat_low`, `n_sat_high`, `n_sat_low_cons`, `n_sat_high_cons` (Int64); `t_sat_lo`, `t_sat_hi` (UInt16) |
+| baseline        | `blmean`, `blsigma`, `blslope`, `bloffset`, `bl_slope_sigma` (Float64) |
+| aux baseline    | `auxbl1_mean/sigma/slope_sigma`, `auxbl2_mean/sigma/slope_sigma` (Float64) |
+| QC              | `qc_label :: Int64` |
+| min/max         | `e_max`, `e_min`, `e_max_pre`, `e_min_pre` (Float64) |
+| tail fit        | `tailmean`, `tailsigma`, `tailslope`, `tailoffset`, `tail_τ`, `tail_mean`, `tail_sigma` (Float64) |
+| aux pole-zero   | `auxpz1_mean/sigma/slope_sigma`, `auxpz2_…` (Float64) |
+| timing          | `t0`, `t10`, `t50`, `t80`, `t90`, `t99`, `t50_pre`, `t50_current`, `drift_time` (Float32) |
+| energy          | `e_10410`, `e_535`, `e_313`, `e_trap`, `e_cusp`, `e_zac`, `e_trap_max`, `e_cusp_max`, `e_zac_max` (Float64) |
+| timing of max   | `t_trap_max`, `t_cusp_max`, `t_zac_max` (Float32) |
+| charge drift / late charge | `qdrift`, `lq` (Float64) |
+| A/E             | `a_sg`, `a_60`, `a_100`, `a_raw` (Float64) |
+| pile-up         | `inTrace_intersect :: Float32`, `inTrace_n :: Int64` |
+| inverted-baseline check | `e_10410_inv`, `e_313_inv` (Float64); `t0_inv` (Float32) |
+
+### 3.3 SPM schema (`S*`, phy only) — 36 columns
+
+```
+/jldsp/<SPMID>/  (table)
+├── timestamp :: Float64
+├── eventID_fadc :: Int32
+├── blfc, e_fc :: UInt16
+├── blmean, blsigma, blslope, bloffset :: Float64
+├── wfmean, wfsigma, wfslope, wfoffset :: Float64
+├── e_max, e_min, e_max_lar, e_min_lar :: Float64
+├── t_max, t_min, t_max_lar, t_min_lar :: Float32
+├── threshold, threshold_DC, threshold_trap, threshold_DC_trap :: Float64
+├── trig_max :: VoV{Float32}                   one entry per trigger
+├── trig_max_DC :: VoV{Float32}
+├── trig_max_trap :: VoV{Float32}
+├── trig_max_DC_trap :: VoV{Float32}
+├── trig_pos :: VoV{Float32}
+├── trig_pos_DC :: VoV{Float32}
+├── trig_pos_trap :: VoV{Float32}
+├── trig_pos_DC_trap :: VoV{Float32}
+├── trig_pos_high_trap :: VoV{Float32}
+├── trig_pos_high_DC_trap :: VoV{Float32}
+├── trig_pos_tot_trap :: VoV{Float32}
+└── trig_pos_tot_DC_trap :: VoV{Float32}
+```
+
+VoV columns use the standard LH5 layout:
+`cumulative_length :: Int64 (n_evts,)` plus `flattened_data :: T (sum_lens,)`.
+
+### 3.4 `MUON01` schema (phy only) — 11 columns
+
+```
+/jldsp/MUON01/  (table)
+├── timestamp, deadtime :: Float64
+├── eventID_fadc :: Int32
+├── e_fc, blfc :: UInt16
+├── blmean, blsigma, blslope, bloffset :: Float64
+├── e_max, e_10410 :: Float64
+└── t50 :: Float32
+```
+
+### 3.5 `PULS01` (phy only)
+
+Stored at `/jldsp/PULS01/` with the GED schema (typically consumed via `jlpls`).
+
+---
+
+## 4. `jlhit` tier (hit-level per detector, `cal` only)
+
+### 4.1 Layout
+
+```
+/
+└── jlhit/
+    └── <DETID>/                exactly one detector per file
+        ├── dataPulser/         (table) DSP rows for pulser-tagged events
+        │   └── <72 GED-DSP columns>
+        ├── dataQC/             (table) DSP rows that pass quality cuts
+        │   └── <72 GED-DSP columns>
+        ├── pulserTag :: Bool (n_all_evts,)   per-event pulser flag
+        └── qc/                 (table, n_all_evts QC flags)
+            ├── is_0_trigs, is_discharge, is_no_NaN, is_physical, is_pileup,
+            │   is_saturated, is_valid_e, is_valid_rms, is_valid_slope,
+            │   is_valid_t0, is_valid_t50, is_valid_t50_classical,
+            │   is_valid_τ, ml :: Bool
+```
+
+`dataPulser` and `dataQC` are **disjoint, pre-filtered** subsets of the run's DSP rows
+and have different lengths from each other and from the unfiltered length.
+`pulserTag` and `qc/*` cover every triggered event in the run (same length each).
+
+The `dataPulser` and `dataQC` columns are exactly the 72 GED DSP columns described
+in §3.2.
+
+---
+
+## 5. `jlevt` tier (event level, all detectors per filekey, `phy` only)
+
+### 5.1 Top-level layout
+
+```
+/
+└── jlevt/                              table { tstart, geds, spms, aux, ged_spm, ft_spm, ged_pmt }
+    ├── tstart :: Float64 (n_evts,)     event start time (UTC)
+    ├── geds/                           table — GED data (event-scalar + VoV columns)
+    ├── spms/                           table — SiPM data (VoV, partly nested)
+    ├── aux/                            sub-group with three tables
+    │   ├── forcedtrigger/              table (8 cols, n_evts)
+    │   ├── muonveto/                   table (8 cols, n_evts)
+    │   └── pulser/                     table (8 cols, n_evts)
+    ├── ged_spm/                        table (7 cols, n_evts)  GED ↔ SiPM coincidence
+    ├── ft_spm/                         table (7 cols, n_evts)  forced-trigger ↔ SiPM
+    └── ged_pmt/                        table (5 cols, n_evts)  GED ↔ PMT coincidence
+```
+
+### 5.2 Index classes inside `jlevt`
+
+The `jlevt/geds` table mixes three column classes that index differently:
+
+1. **Event-scalar** — length `n_evts`, one value per event.
+2. **Per-detector-list VoV** — variable inner length, typically equal to the number of
+   detectors in the array. The inner index runs over all detectors; the column
+   `detector` provides the mapping inner-index ↦ `DetectorId`.
+3. **Per-trigger VoV** — variable inner length, equal to the number of triggers in
+   that event (not all detectors). The column `trig_e_det` provides the mapping
+   inner-index ↦ triggering `DetectorId`, and `trig_e_det_idxs` maps an inner index
+   in the per-trigger view to the corresponding inner index in the per-detector-list
+   view.
+
+The `jlevt/spms` table is uniformly per-detector-list VoV (no per-trigger split), but
+some columns are nested `VoV{VoV{T}}` (one inner vector per SPM, an even-deeper inner
+vector per per-SPM trigger).
+
+### 5.3 `/jlevt/geds/` columns
+
+#### Event-scalar (length `n_evts`)
+
+| Column | Type |
+|--------|------|
+| `is_discharge`, `is_discharge_recovery`, `is_saturated`, `is_valid_hit`, `is_valid_psd`, `is_valid_qc`, `is_valid_trig` | Bool |
+| `max_e_cusp_cal`, `max_e_cusp_ctc_cal`, `max_e_short_cal`, `max_e_trap_cal`, `max_e_trap_ctc_cal` | Float64 |
+| `max_e_det` | UInt32 (`DetectorId`) |
+| `max_e_det_idxs` | Int64 (index into the per-detector-list view) |
+| `multiplicity` | Int64 |
+| `t0_start` | Float32 |
+| `tstart` | Float64 |
+
+#### Per-detector-list VoV (inner length ≈ number of detectors in the array)
+
+| Column | Inner type | Notes |
+|--------|------------|-------|
+| `detector` | UInt32 (`DetectorId`) | inner-index ↦ detector |
+| `dataidx`, `detevtno` | Int64 | indices into `jldsp` |
+| `blmean`, `blsigma`, `qdrift` | Float64 | DSP output |
+| `drift_time`, `t0`, `t50` | Float32 | timing |
+| `timestamp` | Float64 | per-detector timestamp |
+| `qc_label` | Int64 | |
+| `e_535_cal`, `e_cusp_cal`, `e_cusp_ctc_cal`, `e_cusp_max_cal`, `e_trap_cal`, `e_trap_ctc_cal`, `e_trap_max_cal` | Float64 | calibrated energies |
+| `aoe_100_classifier`, `aoe_raw_classifier`, `aoe_sg_classifier` (each with `_ds_cut`, `_low_cut`) | Float64 / Bool | A/E |
+| `lq_classifier` (with `_ds_cut`, `_high_cut`) | Float64 / Bool | LQ |
+| `psd_classifier` | Bool | PSD |
+| `is_0_trigs`, `is_baseline`, `is_baseline_ml`, `is_discharge_recovery_ml`, `is_negative_crosstalk`, `is_nopileup`, `is_nopileup_ml`, `is_physical`, `is_physical_ml`, `is_physical_trig`, `is_valid_bl_mean`, `is_valid_bl_slope`, `is_valid_bl_std`, `is_valid_dteff`, `is_valid_e10410_inv`, `is_valid_max_e10410`, `is_valid_rms`, `is_valid_rt`, `is_valid_slope`, `is_valid_t0`, `is_valid_t0_ml`, `is_valid_t50`, `is_valid_tail`, `is_valid_tail_slope`, `is_valid_τ` | Bool | per-detector QC flags |
+
+#### Per-trigger VoV (inner length ≈ number of triggers per event)
+
+| Column | Inner type | Notes |
+|--------|------------|-------|
+| `trig_e_det` | UInt32 (`DetectorId`) | which detector triggered |
+| `trig_e_det_idxs` | Int64 | inner index of that detector in the per-detector-list view |
+| `trig_e_535_cal`, `trig_e_cusp_ctc_cal`, `trig_e_cusp_max_cal`, `trig_e_trap_ctc_cal`, `trig_e_trap_max_cal` | Float64 | trigger-level energies |
+| `trig_t0` | Float32 | |
+
+### 5.4 `/jlevt/spms/` columns
+
+```
+/jlevt/spms/
+├── tstart :: Float64 (n_evts,)                       event-scalar
+├── dataidx :: VoV{Int64}                             one entry per SPM
+├── detector :: VoV{UInt32, DetectorId}               one entry per SPM
+├── detevtno :: VoV{Int64}                            one entry per SPM
+├── timestamp :: VoV{Float64}                         one entry per SPM
+├── trig_max_cal :: VoV{ VoV{Float64} }               per SPM × per trigger
+├── trig_max_is_dc :: VoV{ VoV{Bool} }                per SPM × per trigger
+├── trig_max_trap_cal :: VoV{ VoV{Float64} }          per SPM × per trigger
+├── trig_max_trap_is_dc :: VoV{ VoV{Bool} }           per SPM × per trigger
+├── trig_pos :: VoV{ VoV{Float32} }                   per SPM × per trigger
+└── trig_pos_trap :: VoV{ VoV{Float32} }              per SPM × per trigger
+```
+
+The SPM table has no per-trigger flat view and no `trig_e_det_idxs` analogue. The
+nested `trig_max_*` and `trig_pos_*` columns carry one inner vector per SPM whose
+elements are per-trigger arrays.
+
+### 5.5 `/jlevt/aux/` — three flat tables (identical schema)
+
+`forcedtrigger/`, `muonveto/`, and `pulser/` each have:
+
+| Column         | Type    |
+|----------------|---------|
+| `tstart`       | Float64 |
+| `dataidx`      | Int64   |
+| `detevtno`     | Int64   |
+| `detector`     | UInt32  |
+| `timestamp`    | Float64 |
+| `e_10410`      | Float64 |
+| `t50`          | Float32 |
+| `aux_trig`     | Bool    |
+
+All three tables have length `n_evts`.
+
+### 5.6 `/jlevt/ged_spm/`, `/jlevt/ft_spm/`, `/jlevt/ged_pmt/` — coincidence tables
+
+All three are flat event-scalar tables of length `n_evts`.
+
+`ged_spm/` and `ft_spm/` (identical schema, 7 columns):
+
+```
+is_valid_lar :: Bool
+trig_max_cal_lar_cut :: Bool
+trig_max_cal_spms_win_multiplicity :: Int64
+trig_max_cal_spms_win_pe_sum :: Float64
+trig_max_trap_cal_lar_cut :: Bool
+trig_max_trap_cal_spms_win_multiplicity :: Int64
+trig_max_trap_cal_spms_win_pe_sum :: Float64
+```
+
+`ged_pmt/` (5 columns):
+
+```
+is_valid_muon :: Bool
+multiplicity :: Int64
+n_hit_window :: Int64
+pe_cal :: Float64
+timestamp :: Float64
+```
+
+---
+
+## 6. `jlpmt` tier (PMT event level, all PMTs per filekey, `phy` only)
+
+One file per filekey, with a single flat table at the root holding every event
+that involves the muon-veto PMT system. Unlike `jlevt`, `jlpmt` has no
+`geds`/`spms`/`aux` substructure — all columns live directly under `/jlpmt`,
+mixing event-scalar columns with per-PMT-list VoVs.
+
+### 6.1 Top-level layout
+
+```
+/
+└── jlpmt/                         table { is_valid_muon, pulse_height_cal_muon_cut,
+                                            pulse_height_cal_pmts_pe_sum,
+                                            pulse_height_cal_pmts_multiplicity,
+                                            tstart, dataidx, detevtno, detector,
+                                            timestamp, pulse_height_cal, t0, t0_low,
+                                            trig_max, trig_pos,
+                                            pulse_height_is_physical_trig }
+```
+
+### 6.2 Index classes
+
+Two column classes are mixed at top level:
+
+1. **Event-scalar** (length `n_evts`): one value per muon-veto event.
+2. **Per-PMT-list VoV** (inner length ≈ number of PMTs read out): one value per
+   PMT in the array. The `detector` column gives the inner-index ↦ `DetectorId`
+   mapping.
+
+There is no per-trigger split (no `trig_e_det` / `trig_e_det_idxs` analogue).
+Multi-trigger information is carried as nested `VoV{VoV{T}}` (inner per-trigger
+of that PMT) for `trig_max` and `trig_pos`.
+
+### 6.3 Column reference
+
+#### Event-scalar (length `n_evts`)
+
+| Column                               | Type    |
+|--------------------------------------|---------|
+| `is_valid_muon`                      | Bool    |
+| `pulse_height_cal_muon_cut`          | Bool    |
+| `pulse_height_cal_pmts_multiplicity` | Int64   |
+| `pulse_height_cal_pmts_pe_sum`       | Float64 |
+| `tstart`                             | Float64 |
+
+#### Per-PMT-list VoV (inner length ≈ number of PMTs)
+
+| Column                          | Inner type            | Notes                          |
+|---------------------------------|-----------------------|--------------------------------|
+| `detector`                      | UInt32 (`DetectorId`) | inner-index ↦ PMT              |
+| `dataidx`, `detevtno`           | Int64                 | indices into `jldsp`           |
+| `timestamp`                     | Float64               | per-PMT timestamp              |
+| `t0`, `t0_low`                  | Float64               | timing                         |
+| `pulse_height_cal`              | Float64               | calibrated pulse height        |
+| `pulse_height_is_physical_trig` | Bool                  | per-PMT physical-trigger flag  |
+
+#### Nested VoV (per-PMT × per-trigger of that PMT)
+
+| Column      | Inner-inner type | Notes                                 |
+|-------------|------------------|---------------------------------------|
+| `trig_max`  | Float64          | one inner Vector per PMT, per trigger |
+| `trig_pos`  | Float64          | same shape                            |
+
+---
+
+## 7. `jlpls` tier (pulser tags, one file per run)
+
+One file per run, with a single sub-group named after the pulser channel. The schema
+differs between `cal` and `phy`.
+
+### 7.1 `cal`: `/jlpls/PULS01/tags`
+
+```
+daqenergy :: UInt16  (n_pulser_evts,)
+timestamp :: Float64 (n_pulser_evts,)
+```
+
+### 7.2 `phy`: `/jlpls/PULS01ANA/tags`
+
+```
+aux_trig  :: Bool    (n_pulser_evts,)
+e_10410   :: Float64 (n_pulser_evts,)
+t50       :: Float32 (n_pulser_evts,)
+timestamp :: Float64 (n_pulser_evts,)
+```
+
+The `jlpls` tier has no per-filekey split; each file holds every pulser event of the
+run.
+
+---
+
+## 8. LH5 datatype reference
+
+LH5 stores the `@datatype` attribute on every group/dataset to describe the logical
+shape on top of the HDF5 native types.
+
+| `datatype` string                                  | Julia representation |
+|----------------------------------------------------|----------------------|
+| `array<1>{real}`                                   | `AbstractVector{<:Real}` |
+| `array<1>{bool}`                                   | `AbstractVector{Bool}` |
+| `array<1>{detectorid}`                             | `AbstractVector{DetectorId}` (UInt32-encoded) |
+| `array<1>{array<1>{real}}`                         | VoV of reals: `cumulative_length` + `flattened_data` |
+| `array<1>{array<1>{bool}}`                         | VoV of `Bool` |
+| `array<1>{array<1>{detectorid}}`                   | VoV of `DetectorId` |
+| `array<1>{array<1>{array<1>{real}}}`               | nested VoV (two levels of `cumulative_length`) |
+| `array_of_equalsized_arrays<1,1>{real}`            | 2-D dataset, e.g. (samples × events) for raw waveforms |
+| `array_of_encoded_equalsized_arrays<1,1>{real}`    | encoded waveform group with a `codec` attribute |
+| `table{col1, col2, …}`                             | group whose children are the table's columns (read as `Table`) |
+| `struct{key1, key2, …}`                            | group read as `NamedTuple` |
+| `real`                                             | scalar real dataset |

--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -35,11 +35,9 @@ function det_sg_optimization(chinfo_det::NamedTuple)
 
         @info "Processing detector $det ($ch)"
 
-        mkpath(joinpath(data_path(l200.par.ppars.aoeopt), string(det)))
         pars_db_det = if isfile(joinpath(data_path(l200.par.ppars.aoeopt), "$det", "$part.yaml")) && !reprocess
             PropDict(l200.par.ppars.aoeopt[det, part])
         else
-            mkpath(joinpath(data_path(l200.par.ppars.aoeopt), "$det"))
             PropDict()
         end
 

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -33,11 +33,9 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         det = chinfo_det.detector
         part = chinfo_det.partition
 
-        mkpath(joinpath(data_path(l200.par.ppars.pz), string(det)))
         pars_db_det = if isfile(joinpath(data_path(l200.par.ppars.pz), "$det", "$part.yaml"))
             PropDict(l200.par.ppars.pz[det, part])
         else
-            mkpath(joinpath(data_path(l200.par.ppars.pz), "$det"))
             PropDict()
         end
 

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -35,11 +35,9 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
 
         @debug "Processing detector $det ($ch)"
         
-        mkpath(joinpath(data_path(l200.par.ppars.fltopt), string(det)))
         pars_db_det = if isfile(joinpath(data_path(l200.par.ppars.fltopt[det]), "$part.yaml"))
             PropDict(l200.par.ppars.fltopt[det, part])
         else
-            mkpath(joinpath(data_path(l200.par.ppars.fltopt), "$det"))
             PropDict()
         end
 

--- a/processors/p_process_skm_phy.jl
+++ b/processors/p_process_skm_phy.jl
@@ -46,13 +46,10 @@ function p_process_skm_phy(processing_config::PropDict, l200::LegendData, period
                 rm(skmfilename, force=true)
             elseif isfile(outfilename)
                 @info "File $(basename(skmfilename)) already exists, skip"
-                n_psd, n_lar, n_larpsd = lh5open(outfilename, "r") do ds
-                    skm_data = ds[:skm][:]
-                    n_psd = mean(skm_data.geds.is_valid_psd) * 100u"percent"
-                    n_lar = mean(skm_data.ged_spm.is_valid_lar) * 100u"percent"
-                    n_larpsd = mean(skm_data.geds.is_valid_psd .&& skm_data.ged_spm.is_valid_lar) * 100u"percent"
-                    n_psd, n_lar, n_larpsd
-                end
+                skm_data = read_ldata(l200, DataTier(:jlskm), fk)
+                n_psd = mean(skm_data.geds.is_valid_psd) * 100u"percent"
+                n_lar = mean(skm_data.ged_spm.is_valid_lar) * 100u"percent"
+                n_larpsd = mean(skm_data.geds.is_valid_psd .&& skm_data.ged_spm.is_valid_lar) * 100u"percent"
                 return (timer = dsp_timer, log = log_nt((fk, ProcessStatus(1), n_larpsd, n_lar, n_psd, "", "", "")), processed = false)
             end
 

--- a/processors/process_aoe_optimization.jl
+++ b/processors/process_aoe_optimization.jl
@@ -82,21 +82,19 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
         
         wvfs_det_sep_wdw, wvfs_det_sep_pre, wvfs_det_dep_wdw, wvfs_det_dep_pre, presum_rate = nothing, nothing, nothing, nothing, nothing
         try
-            data = lh5open(filename, "r")
+            peaks = read_ldata(l200, DataTier(:jlpeaks), filekey, det)
 
-            @debug "Loading Tl208 SEP and DEP data from $(filename)"
-            wvfs_det_dep_bi121fep_wdw = data[det].jlpeaks.Tl208DEP_Bi212FEP.waveform_windowed[:]
-            wvfs_det_dep_bi121fep_pre = data[det].jlpeaks.Tl208DEP_Bi212FEP.waveform_presummed[:]
-            presum_rate               = data[det].jlpeaks.Tl208SEP.presum_rate[1]
-            e_det_dep_bi121fep        = data[det].jlpeaks.Tl208DEP_Bi212FEP.daqenergy[:]
+            @debug "Loading Tl208 SEP and DEP data via read_ldata"
+            wvfs_det_dep_bi121fep_wdw = peaks.Tl208DEP_Bi212FEP.waveform_windowed
+            wvfs_det_dep_bi121fep_pre = peaks.Tl208DEP_Bi212FEP.waveform_presummed
+            presum_rate               = peaks.Tl208SEP.presum_rate[1]
+            e_det_dep_bi121fep        = peaks.Tl208DEP_Bi212FEP.daqenergy
             # wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_det.dep_sep_quantile)]
             wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw
             # wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_det.dep_sep_quantile)]
             wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre
-            wvfs_det_sep_wdw          = data[det].jlpeaks.Tl208SEP.waveform_windowed[:]
-            wvfs_det_sep_pre          = data[det].jlpeaks.Tl208SEP.waveform_presummed[:]
-
-            close(data)
+            wvfs_det_sep_wdw          = peaks.Tl208SEP.waveform_windowed
+            wvfs_det_sep_pre          = peaks.Tl208SEP.waveform_presummed
         catch e
             @error "DEP and SEP data from $(part) cannot be loaded: $(truncate_error(e))"
             throw(LoadError(string(part), 154,"DEP and SEP data from $(part) cannot be loaded: $(truncate_error(e))"))

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -68,10 +68,8 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
         # load data
         wvfs_det = nothing
         try
-            data = lh5open(filename, "r")
-            @debug "Loading $peakname data from $(filename)"
-            wvfs_det = data[det, :jlpeaks, peakname].waveform_presummed[:]
-            close(data)
+            @debug "Loading $peakname data via read_ldata"
+            wvfs_det = read_ldata(l200, DataTier(:jlpeaks), filekey, det)[peakname].waveform_presummed
             if length(wvfs_det) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
                 sel = rand(1:max_wvfs, max_wvfs)

--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -84,99 +84,95 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
         # detector ids of failed detectors
         failed_detectors = DetectorId[]
         # start processing
-        read_files(rawfilename, use_cache = false) do filename
-            write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
-                @timeit dsp_timer "Startup" begin
-                    raw_data = lh5open(filename, "r")
-                    if reprocess && isfile(dspfilename)
-                        @info "Reprocess $(basename(dspfilename)), remove old DSP."
-                        rm(outfilename, force=true)
-                    end
+        write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
+            @timeit dsp_timer "Startup" begin
+                if reprocess && isfile(dspfilename)
+                    @info "Reprocess $(basename(dspfilename)), remove old DSP."
+                    rm(outfilename, force=true)
                 end
-
-                # open output file
-                outdata = lh5open(outfilename, "cw")
-                # get processed detectors
-                processed_channels = keys(outdata)
-
-                @info "Start DSP"
-                @timeit dsp_timer "DSP" begin
-                    # loop over detectors
-                    @showprogress desc="Filekey: $fk" output=stdout for chinfo_det in chinfo
-                        
-                        ch = chinfo_det.channel
-                        det = chinfo_det.detector
-
-                        dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
-                        dsp_config_det = DSPConfig(dsp_config_pd_det)
-                        @debug "Loaded DSP config: $(lstring(dsp_config_det))"
-
-                        # check if channel can be processed
-                        if "$det" in processed_channels && !reprocess
-                            @info "Detector $det ($ch) already processed, skip"
-                            n_detectors += 1
-                            continue
-                        end
-                        
-                        # check for decay time
-                        if !haskey(pars_tau, det)
-                            @warn "No decay time for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-                        # check if channel has values for RT and FT for different filters
-                        if !haskey(pars_fltoptimization, det)
-                            @warn "No optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if channel has all required flt opt pars
-                        if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
-                            @warn "Not all required energy filter optimization parameters available for detector $det, skip"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if channel has all required aoe opt pars
-                        if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
-                            @warn "Not all required A/E optimization parameters available for detector $det, skip"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        @debug "Processing detector $det ($ch)"
-                        @timeit dsp_timer "DSP $det" begin
-                            # process data
-                            outdata_det = nothing
-                            try
-                                outdata_det = dsp_icpc_compressed(raw_data[det].raw[:], dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
-                            catch e
-                                if e isa TaskFailedException
-                                    e = e.task.exception
-                                end
-                                @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                push!(failed_detectors, det)
-                                continue
-                            end
-                            # save data to hdf5
-                            outdata[det, :jldsp] = outdata_det
-                            # free memory
-                            GC.gc()
-                            # count number of detectors processed and Successful
-                            n_detectors += 1
-                            # flush streams
-                            flush(stdout)
-                            flush(stderr)
-                        end
-                    end
-                    # close outdata file
-                    close(outdata)
-                end
-                @info "Finished processing file: $(basename(rawfilename))"
-                close(raw_data)
-                # return number of processed detectors and failed detectors
             end
+
+            # open output file
+            outdata = lh5open(outfilename, "cw")
+            # get processed detectors
+            processed_channels = haskey(outdata, "jldsp") ? keys(outdata["jldsp"]) : String[]
+
+            @info "Start DSP"
+            @timeit dsp_timer "DSP" begin
+                # loop over detectors
+                @showprogress desc="Filekey: $fk" output=stdout for chinfo_det in chinfo
+                    
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+
+                    dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
+                    dsp_config_det = DSPConfig(dsp_config_pd_det)
+                    @debug "Loaded DSP config: $(lstring(dsp_config_det))"
+
+                    # check if channel can be processed
+                    if "$det" in processed_channels && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+                    
+                    # check for decay time
+                    if !haskey(pars_tau, det)
+                        @warn "No decay time for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+                    # check if channel has values for RT and FT for different filters
+                    if !haskey(pars_fltoptimization, det)
+                        @warn "No optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if channel has all required flt opt pars
+                    if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
+                        @warn "Not all required energy filter optimization parameters available for detector $det, skip"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if channel has all required aoe opt pars
+                    if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
+                        @warn "Not all required A/E optimization parameters available for detector $det, skip"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # process data
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_icpc_compressed(read_ldata(l200, DataTier(:raw), fk, det), dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+                # close outdata file
+                close(outdata)
+            end
+            @info "Finished processing file: $(basename(rawfilename))"
+            # return number of processed detectors and failed detectors
         end
         if n_detectors == 0
             @warn "No detectors processed in $(basename(rawfilename))"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -94,160 +94,25 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
         # detector ids of failed detectors
         failed_detectors = DetectorId[]
         # start processing
-        read_files(rawfilename, use_cache = false) do filename
-            write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
-                @timeit dsp_timer "Startup" begin
-                    raw_data = lh5open(filename, "r")
-                    if reprocess && isfile(outfilename)
-                        @info "Reprocess $(basename(outfilename)), remove old DSP."
-                        rm(outfilename, force=true)
-                    end
+        write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
+            @timeit dsp_timer "Startup" begin
+                if reprocess && isfile(outfilename)
+                    @info "Reprocess $(basename(outfilename)), remove old DSP."
+                    rm(outfilename, force=true)
                 end
+            end
 
-                # open output file
-                outdata = lh5open(outfilename, "cw")
-                # get processed detectors
-                processed_detectors = keys(outdata)
+            # open output file
+            outdata = lh5open(outfilename, "cw")
+            # get processed detectors
+            processed_detectors = haskey(outdata, "jldsp") ? keys(outdata["jldsp"]) : String[]
 
-                @info "Start DSP"
-                @timeit dsp_timer "DSP" begin
-                    if haskey(dsp_config_pd, :additional_detectors)
-                        # process additional detectors
-                        for det in DetectorId.(keys(dsp_config_pd.additional_detectors))
-                            ch = channelinfo(l200, filekey, det).channel
-
-                            dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
-                            dsp_config_det = DSPConfig(dsp_config_pd_det)
-                            @debug "Loaded DSP config: $(lstring(dsp_config_det))"
-
-                            # check if detector can be processed
-                            if "$det" in processed_detectors && !reprocess
-                                @info "Detector $det ($ch) already processed, skip"
-                                n_detectors += 1
-                                continue
-                            end
-
-                            @debug "Processing detector $det ($ch)"
-                            @timeit dsp_timer "DSP $det" begin
-                                # process data
-                                outdata_det = nothing
-                                try
-                                    outdata_det = getfield(LegendDSP, Symbol(dsp_config_pd.additional_detectors[Symbol(det)]))(raw_data[det].raw[:], dsp_config_det)
-                                catch e
-                                    if e isa TaskFailedException
-                                        e = e.task.exception
-                                    end
-                                    @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                    push!(failed_detectors, det)
-                                    continue
-                                end
-                                # save data to hdf5
-                                outdata[det, :jldsp] = outdata_det
-                                # free memory
-                                GC.gc()
-                                # count number of detectors processed and Successful
-                                n_detectors += 1
-                            end
-                        end
-                    end
-
-                    # loop over detectors
-                    if all(.!haskey.(Ref(raw_data), string.(chinfo_pmts.detector)))
-                        @warn "No PMT data found in $(fk), skip PMT processing"
-                        n_detectors += length(chinfo_pmts)
-                    else
-                        @showprogress desc="Filekey PMTS: $fk" output=stdout for chinfo_det in chinfo_pmts
-
-                            ch = chinfo_det.channel
-                            det = chinfo_det.detector
-            
-                            # check if detector can be processed
-                            if "$det" in processed_detectors && !reprocess
-                                @info "Detector $det ($ch) already processed, skip"
-                                n_detectors += 1
-                                continue
-                            end
-            
-                            @debug "Processing detector $det ($ch)"
-                            @timeit dsp_timer "DSP $det" begin
-                                # get metadata
-                                dsp_meta_det = merge(dsp_meta_pmt.default, get(dsp_meta_pmt, det, PropDict()))
-                                # process detector
-                                outdata_det = nothing
-                                try
-                                    outdata_det = dsp_pmts(raw_data[det].raw[:], dsp_meta_det)
-                                catch e
-                                    if e isa TaskFailedException
-                                        e = e.task.exception
-                                    end
-                                    @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                    push!(failed_detectors, det)
-                                    continue
-                                end
-                                # save data to hdf5
-                                outdata[det, :jldsp] = outdata_det
-                                # free memory
-                                GC.gc()
-                                # count number of detectors processed and Successful
-                                n_detectors += 1
-                                # flush streams
-                                flush(stdout)
-                                flush(stderr)
-                            end
-                        end
-                    end
-
-                    # loop over detectors
-                    @showprogress desc="Filekey SiPM: $fk" output=stdout for chinfo_det in chinfo_sipm
-
-                        ch = chinfo_det.channel
-                        det = chinfo_det.detector
-        
-                        # check if detector can be processed
-                        if !haskey(pars_sipm, det)
-                            @warn "No thresholds for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-                        if "$det" in processed_detectors && !reprocess
-                            @info "Detector $det ($ch) already processed, skip"
-                            n_detectors += 1
-                            continue
-                        end
-        
-                        @debug "Processing detector $det ($ch)"
-                        @timeit dsp_timer "DSP $det" begin
-                            # get metadata
-                            dsp_meta_det = merge(dsp_meta_sipm.default, get(dsp_meta_sipm, det, PropDict()))
-                            # process detector
-                            outdata_det = nothing
-                            try
-                                outdata_det = dsp_sipm_compressed(raw_data[det].raw[:], dsp_meta_det, pars_sipm[det])
-                            catch e
-                                if e isa TaskFailedException
-                                    e = e.task.exception
-                                end
-                                @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                push!(failed_detectors, det)
-                                continue
-                            end
-                            # save data to hdf5
-                            outdata[det, :jldsp] = outdata_det
-                            # free memory
-                            GC.gc()
-                            # count number of detectors processed and Successful
-                            n_detectors += 1
-                            # flush streams
-                            flush(stdout)
-                            flush(stderr)
-                        end
-                    end
-
-                    # loop over detectors
-                    @showprogress desc="Filekey HPGe: $fk" output=stdout for chinfo_det in chinfo
-
-                        ch = chinfo_det.channel
-                        det = chinfo_det.detector
+            @info "Start DSP"
+            @timeit dsp_timer "DSP" begin
+                if haskey(dsp_config_pd, :additional_detectors)
+                    # process additional detectors
+                    for det in DetectorId.(keys(dsp_config_pd.additional_detectors))
+                        ch = channelinfo(l200, filekey, det).channel
 
                         dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
                         dsp_config_det = DSPConfig(dsp_config_pd_det)
@@ -260,39 +125,12 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                             continue
                         end
 
-                        # check for decay time
-                        if !haskey(pars_tau, det)
-                            @warn "No decay time for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-                        # check if detector has values for RT and FT for different filters
-                        if !haskey(pars_fltoptimization, det)
-                            @warn "No optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if detector has all required flt opt pars
-                        if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
-                            @warn "Not all required energy filter optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if detector has all required aoe opt pars
-                        if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
-                            @warn "Not all required A/E optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
                         @debug "Processing detector $det ($ch)"
                         @timeit dsp_timer "DSP $det" begin
                             # process data
                             outdata_det = nothing
                             try
-                                outdata_det = dsp_icpc_compressed(raw_data[det].raw[:], dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
+                                outdata_det = getfield(LegendDSP, Symbol(dsp_config_pd.additional_detectors[Symbol(det)]))(read_ldata(l200, DataTier(:raw), fk, det), dsp_config_det)
                             catch e
                                 if e isa TaskFailedException
                                     e = e.task.exception
@@ -302,25 +140,178 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                                 continue
                             end
                             # save data to hdf5
-                            outdata[det, :jldsp] = outdata_det
+                            outdata[:jldsp, det] = outdata_det
                             # free memory
                             GC.gc()
                             # count number of detectors processed and Successful
                             n_detectors += 1
-                            # flush streams
-                            flush(stdout)
-                            flush(stderr)
                         end
                     end
-                    # close outdata file
-                    close(outdata)
                 end
-                @info "Finished processing file: $(basename(filename))"
-                close(raw_data)
+
+                # loop over PMT detectors
+                @showprogress desc="Filekey PMTS: $fk" output=stdout for chinfo_det in chinfo_pmts
+
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+
+                    # check if detector can be processed
+                    if "$det" in processed_detectors && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # get metadata
+                        dsp_meta_det = merge(dsp_meta_pmt.default, get(dsp_meta_pmt, det, PropDict()))
+                        # process detector
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_pmts(read_ldata(l200, DataTier(:raw), fk, det), dsp_meta_det)
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+
+                # loop over SiPM detectors
+                @showprogress desc="Filekey SiPM: $fk" output=stdout for chinfo_det in chinfo_sipm
+
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+    
+                    # check if detector can be processed
+                    if !haskey(pars_sipm, det)
+                        @warn "No thresholds for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+                    if "$det" in processed_detectors && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+    
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # get metadata
+                        dsp_meta_det = merge(dsp_meta_sipm.default, get(dsp_meta_sipm, det, PropDict()))
+                        # process detector
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_sipm_compressed(read_ldata(l200, DataTier(:raw), fk, det), dsp_meta_det, pars_sipm[det])
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+
+                # loop over HPGe detectors
+                @showprogress desc="Filekey HPGe: $fk" output=stdout for chinfo_det in chinfo
+
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+
+                    dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
+                    dsp_config_det = DSPConfig(dsp_config_pd_det)
+                    @debug "Loaded DSP config: $(lstring(dsp_config_det))"
+
+                    # check if detector can be processed
+                    if "$det" in processed_detectors && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+
+                    # check for decay time
+                    if !haskey(pars_tau, det)
+                        @warn "No decay time for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+                    # check if detector has values for RT and FT for different filters
+                    if !haskey(pars_fltoptimization, det)
+                        @warn "No optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if detector has all required flt opt pars
+                    if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
+                        @warn "Not all required energy filter optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if detector has all required aoe opt pars
+                    if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
+                        @warn "Not all required A/E optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # process data
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_icpc_compressed(read_ldata(l200, DataTier(:raw), fk, det), dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+                # close outdata file
+                close(outdata)
             end
+            @info "Finished processing file: $(basename(rawfilename))"
         end
         if n_detectors == 0
-            @warn "No detectors processed in $(basename(filename))"
+            @warn "No detectors processed in $(basename(rawfilename))"
         end
 
         # create total timer by summing over memory usage and time

--- a/processors/process_evt_phy.jl
+++ b/processors/process_evt_phy.jl
@@ -29,65 +29,58 @@ function process_evt_phy(processing_config::PropDict, l200::LegendData, period::
         # number of forced, pulser and physical triggers
         n_forced, n_pulser, n_phy = 0, 0, 0
         # start processing
-        read_files(dspfilename, use_cache = false) do filename
-            write_files(evtfilename, use_cache = true, mode = CreateOrModify()) do outfilename
+        write_files(evtfilename, use_cache = true, mode = CreateOrModify()) do outfilename
                 if reprocess && isfile(outfilename)
                     @info "Reprocess $(basename(evtfilename)), remove old Evt."
                     rm(outfilename, force=true)
                     rm(evtfilename, force=true)
                 elseif isfile(outfilename)
                     @info "File $(basename(evtfilename)) already exists, skip"
-                    n_forced, n_pulser, n_phy = lh5open(outfilename, "r") do ds
-                        evt_data = ds[:jlevt][:]
-                        n_forced = count(evt_data.aux.forcedtrigger.aux_trig)
-                        n_pulser = count(evt_data.aux.pulser.aux_trig)
-                        n_phy = count(evt_data.geds.is_valid_qc .&& length.(evt_data.geds.trig_e_det) .> 1)
-                        n_forced, n_pulser, n_phy
-                    end
+                    evt_data = read_ldata(l200, DataTier(:jlevt), fk)
+                    n_forced = count(evt_data.aux.forcedtrigger.aux_trig)
+                    n_pulser = count(evt_data.aux.pulser.aux_trig)
+                    n_phy = count(evt_data.geds.is_valid_qc .&& length.(evt_data.geds.trig_e_det) .> 1)
                     return (timer = dsp_timer, log = log_nt((fk, ProcessStatus(1), n_phy, n_forced, n_pulser, "", "", "")), processed = false)
                 end
 
                 # open output file
                 @timeit dsp_timer "Evt" begin
-                    n_forced, n_pulser, n_phy = lh5open(filename, "r") do dsp_data
-                        # generate evt level table
-                        out_t, pmts_out_t = nothing, nothing
-                        try 
-                            out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data)
-                        catch e
-                            @error "Error processing $fk: $(truncate_error(e))"
-                            throw(ErrorException("Error processing $fk: $(truncate_error(e))"))
-                        end
-                        # get number of forced, physical and pulser triggers
-                        n_forced = count(out_t.aux.forcedtrigger.aux_trig)
-                        @debug "Number of forced triggers: $n_forced"
-                        n_pulser = count(out_t.aux.pulser.aux_trig)
-                        @debug "Number of pulser triggers: $n_pulser"
-                        n_phy = count(out_t.geds.is_valid_qc .&& length.(out_t.geds.trig_e_det) .> 1)
-                        @debug "Number of physical triggers: $n_phy"
-                        lh5open(outfilename, "cw") do ds
-                            ds[:jlevt] = out_t
-                        end
-                        # write pmt evt file
-                        if !isempty(pmts_out_t)
-                            write_files(pmtevtfilename, use_cache = true, mode = CreateOrModify()) do pmtoutfilename
-                                # Remove cached PMT file if reprocess is enabled
-                                if reprocess && isfile(pmtoutfilename)
-                                    @info "Reprocess $(basename(pmtevtfilename)), remove old PMT."
-                                    rm(pmtoutfilename, force=true)
-                                    rm(pmtevtfilename, force=true)
-                                end
-                                lh5open(pmtoutfilename, "cw") do ds
-                                    ds[:jlpmt] = pmts_out_t
-                                end
+                    # generate evt level table
+                    dsp_data = read_ldata(l200, DataTier(:jldsp), fk)
+                    out_t, pmts_out_t = nothing, nothing
+                    try 
+                        out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data)
+                    catch e
+                        @error "Error processing $fk: $(truncate_error(e))"
+                        throw(ErrorException("Error processing $fk: $(truncate_error(e))"))
+                    end
+                    # get number of forced, physical and pulser triggers
+                    n_forced = count(out_t.aux.forcedtrigger.aux_trig)
+                    @debug "Number of forced triggers: $n_forced"
+                    n_pulser = count(out_t.aux.pulser.aux_trig)
+                    @debug "Number of pulser triggers: $n_pulser"
+                    n_phy = count(out_t.geds.is_valid_qc .&& length.(out_t.geds.trig_e_det) .> 1)
+                    @debug "Number of physical triggers: $n_phy"
+                    lh5open(outfilename, "cw") do ds
+                        ds[:jlevt] = out_t
+                    end
+                    # write pmt evt file
+                    if !isempty(pmts_out_t)
+                        write_files(pmtevtfilename, use_cache = true, mode = CreateOrModify()) do pmtoutfilename
+                            # Remove cached PMT file if reprocess is enabled
+                            if reprocess && isfile(pmtoutfilename)
+                                @info "Reprocess $(basename(pmtevtfilename)), remove old PMT."
+                                rm(pmtoutfilename, force=true)
+                                rm(pmtevtfilename, force=true)
+                            end
+                            lh5open(pmtoutfilename, "cw") do ds
+                                ds[:jlpmt] = pmts_out_t
                             end
                         end
-                        n_forced, n_pulser, n_phy
                     end
                 end
                 
                 @info "Finished processing $(basename(evtfilename))"
-            end
         end
 
         # create total timer by summing over memory usage and time

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -85,12 +85,11 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
         # load data
         wvfs_det_pre, wvfs_det_wdw, presum_rate = nothing, nothing, nothing
         try
-            data = lh5open(filename, "r")
-            @debug "Loading Tl208 FEP data from $(filename)"
-            wvfs_det_pre = data[det, :jlpeaks, peakname].waveform_presummed[:]
-            wvfs_det_wdw = data[det, :jlpeaks, peakname].waveform_windowed[:]
-            presum_rate = data[det, :jlpeaks, peakname].presum_rate[:]
-            close(data)
+            @debug "Loading $peakname data via read_ldata"
+            peak_data = read_ldata(l200, DataTier(:jlpeaks), filekey, det)[peakname]
+            wvfs_det_pre = peak_data.waveform_presummed
+            wvfs_det_wdw = peak_data.waveform_windowed
+            presum_rate = peak_data.presum_rate
             if length(wvfs_det_pre) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
                 sel = rand(1:max_wvfs, max_wvfs)

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -55,7 +55,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         write_files(pulserfilename, use_cache=true, mode = CreateOrReplace()) do outfilename
             lh5open(outfilename, "w") do outdata
                 @info "Save Pulser Tags"
-                outdata[det_puls, :jlpls, :tags] = data_puls;
+                outdata[:jlpls, det_puls, :tags] = data_puls;
             end
         end
         return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(data_puls), "-")))
@@ -159,13 +159,13 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         write_files(hitdetfilename, use_cache = true, mode = CreateOrReplace()) do outfilename
             lh5open(outfilename, "w") do outdata
                 @info "Save QC"
-                outdata[det, :jlhit, :qc] = Table(merge(columns(qc), (is_physical = is_physical,)));
+                outdata[:jlhit, det, :qc] = Table(merge(columns(qc), (is_physical = is_physical,)));
                 @info "Save Pulser Tags"
-                outdata[det, :jlhit, :pulserTag] = is_pulser;
+                outdata[:jlhit, det, :pulserTag] = is_pulser;
                 @info "Save data after QC"
-                outdata[det, :jlhit, :dataQC] = data_det_after_qc;
+                outdata[:jlhit, det, :dataQC] = data_det_after_qc;
                 @info "Save data pulser"
-                outdata[det, :jlhit, :dataPulser] = data_pulser;
+                outdata[:jlhit, det, :dataPulser] = data_pulser;
             end
         end
 

--- a/processors/process_peak_split.jl
+++ b/processors/process_peak_split.jl
@@ -33,22 +33,8 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
 
     @info "Expecting $(length(detectors)) detectors each file in \"$input_datadir\"."
 
-    function get_daqenergy_for_det(filelist::AbstractVector{<:AbstractString}, det::DetectorId)
-        fast_flatten([
-            LHDataStore(
-                ds -> begin
-                    @debug "Reading DAQ energy for detector $det from \"$(ds.data_store.filename)\""
-                    ds[det].raw.daqenergy[:]
-                end,
-                filename
-            ) for filename in filelist
-        ])
-    end
-
-    function channels_in_file(filename)
-        LHDataStore(filename) do ds
-            sort(chname2int.(filter(startswith("ch"), keys(ds))))
-        end
+    function get_daqenergy_for_det(keys::AbstractVector{FileKey}, det::DetectorId)
+        fast_flatten([read_ldata(:daqenergy, l200, DataTier(:raw), fk, det).daqenergy for fk in keys])
     end
 
     # get keylists and check files
@@ -140,17 +126,15 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
 
         energy_windows = IdDict(keys(raw_config_det.peaks) .=> [first(v)..last(v) for v in values(raw_config_det.peaks)])
 
-        filelist = [l200.tier[:raw, key] for key in filekeys]
         output_filename = l200.tier[:jlpeaks, first(filekeys), det]
 
         if isfile(output_filename) && !reprocess
             @info "Output file \"$output_filename\" already exists, skipping"
             n_sep, n_fep = nothing, nothing
             try
-                output = lh5open(output_filename, "r")
-                n_sep = length(output[det].jlpeaks.Tl208SEP.daqenergy)
-                n_fep = length(output[det].jlpeaks.Tl208FEP.daqenergy)
-                close(output)
+                output_data = read_ldata(l200, DataTier(:jlpeaks), first(filekeys), det)
+                n_sep = length(output_data.Tl208SEP.daqenergy)
+                n_fep = length(output_data.Tl208FEP.daqenergy)
             catch e
                 @error "Error reading SEP and FEP events from $(basename(output_filename)): $(truncate_error(e))"
                 @warn "Filename $(basename(output_filename)) seems broken, remove it."
@@ -168,7 +152,7 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
         @timeit split_timer "$det" begin
             # get raw daqenergy
             @timeit split_timer "Get DAQ Energy" begin
-                e_raw = get_daqenergy_for_det(filelist, det)
+                e_raw = get_daqenergy_for_det(filekeys, det)
                 @info "Auto calibrating $det ($ch)"
                 result_autocal, report_autocal = autocal_energy(e_raw, raw_config_det.th228_cal_lines; mode=:ratio, min_e=raw_config_det.min_e, max_e=raw_config_det.max_e, max_e_binning_quantile=raw_config_det.max_e_binning_quantile, σ=raw_config_det.σ, threshold=raw_config_det.threshold, min_n_peaks=raw_config_det.min_n_peaks, max_n_peaks=raw_config_det.max_n_peaks, α=raw_config_det.α, rtol=raw_config_det.rtol)
                 f_calib = result_autocal.f_calib
@@ -178,11 +162,10 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
             GC.gc()
             @info "Filtering detector $det ($ch)"
             @timeit split_timer "Filter Raw" begin
-                slim_data = flatten_by_key([lh5open(filename) do ds
-                    @debug "Filtering $(filename) for detector $det ($ch)"
-                    filter_raw_data_by_energy(ds[det].raw[:], f_calib, energy_windows; chunk_size=100)
-                    # filter_raw_data_by_energy(Table(decode_data(ds[det].raw[:])), f_calib, energy_windows)
-                end for filename in filelist])
+                slim_data = flatten_by_key([begin
+                    @debug "Filtering filekey $(key) for detector $det ($ch)"
+                    filter_raw_data_by_energy(read_ldata(l200, DataTier(:raw), key, det), f_calib, energy_windows; chunk_size=100)
+                end for key in filekeys])
             end
             n_fep = length(slim_data[:Tl208FEP].daqenergy)
             n_sep = length(slim_data[:Tl208SEP].daqenergy)
@@ -196,7 +179,7 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
                 write_files(output_filename, use_cache = false, mode = CreateOrReplace()) do outfile
                     lh5open(outfile, "w") do output
                         for label in sort(collect(keys(slim_data)))
-                            output[det, :jlpeaks, label] = slim_data[label]
+                            output[:jlpeaks, det, label] = slim_data[label]
                             # output[det, :jlpeaks, label] = decode_data(slim_data[label])
                         end
                     end

--- a/processors/process_sipm_optimization_phy.jl
+++ b/processors/process_sipm_optimization_phy.jl
@@ -50,7 +50,7 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         pulserfilename = l200.tier[:jlpls, filekey, det_puls]
 
         if !reprocess && isfile(pulserfilename)
-            return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(lh5open(pulserfilename)[det_puls, :jlpls, :tags]), "Already processed --> skipped.")))
+            return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(read_ldata(l200, DataTier(:jlpls), filekey, det_puls)), "Already processed --> skipped.")))
         end
         # extract pulser events by loading data from raw files
         @info "Get pulser events from raw data"
@@ -73,7 +73,7 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         write_files(pulserfilename, use_cache=true, mode = CreateOrReplace()) do outfilename
             lh5open(outfilename, "w") do outdata
                 @info "Save Pulser Tags"
-                outdata[det_puls, :jlpls, :tags] = data_puls;
+                outdata[:jlpls, det_puls, :tags] = data_puls;
             end
         end
         return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(data_puls), "Already processed --> skipped.")))


### PR DESCRIPTION
Key changes: 
1. read_ldata for tier inputs — replace lh5open/read_files plumbing with read_ldata(l200, DataTier(...), fk, det) for per-detector loads
2. Unified tier/$det/... write layout — flip every per-detector write from outdata[det, :tier, ...] to outdata[:tier, det, ...] so all tiers (jldsp, jlhit with qc/pulserTag/dataQC/dataPulser, jlpls/tags) share the same group structure.
3. ppars cleanup (p_process_aoe_optimization, p_process_decay_time, p_process_filter_optimization): drop the pre-processing mkpath; writelprops creates the ppars directory itself, so failed processors no longer leave empty folders containing only a stale validity.yaml