### PR TITLE
processors: read input via read_ldata instead of lh5open

### DIFF
--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -108,11 +108,14 @@ function det_sg_optimization(chinfo_det::NamedTuple)
         wvfs_det_sep_wdw, wvfs_det_sep_pre, wvfs_det_dep_wdw, wvfs_det_dep_pre, presum_rate = nothing, nothing, nothing, nothing, nothing
         try
             @debug "Loading Tl208 SEP and DEP data from $(part), select $(ifelse(select_random, "randomly", "")) $n_evts events from each run"
-            data = read_ldata((:Tl208DEP_Bi212FEP, :Tl208SEP), l200, DataTier(:jlpeaks), :cal, partinfo_det, det; n_evts=n_evts)
-            wvfs_det_dep_bi121fep_wdw = data.Tl208DEP_Bi212FEP.waveform_windowed[:]
-            wvfs_det_dep_bi121fep_pre = data.Tl208DEP_Bi212FEP.waveform_presummed[:]
-            presum_rate              = data.Tl208SEP.presum_rate[1]
-            e_det_dep_bi121fep        = data.Tl208DEP_Bi212FEP.daqenergy[:]
+            # per-peak subgroup reads with column selection: avoids loading every peak
+            # with all waveform variants; n_evts samples with one shared row index per run
+            data_dep = read_ldata((:waveform_windowed, :waveform_presummed, :daqenergy), l200, DataTier(:jlpeaks), :cal, partinfo_det, det; subgroup=:Tl208DEP_Bi212FEP, n_evts=n_evts)
+            data_sep = read_ldata((:waveform_windowed, :waveform_presummed, :presum_rate), l200, DataTier(:jlpeaks), :cal, partinfo_det, det; subgroup=:Tl208SEP, n_evts=n_evts)
+            wvfs_det_dep_bi121fep_wdw = data_dep.waveform_windowed[:]
+            wvfs_det_dep_bi121fep_pre = data_dep.waveform_presummed[:]
+            presum_rate              = data_sep.presum_rate[1]
+            e_det_dep_bi121fep        = data_dep.daqenergy[:]
             # DEP
             # wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_ch.dep_sep_quantile)]
             wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw
@@ -120,16 +123,16 @@ function det_sg_optimization(chinfo_det::NamedTuple)
             wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre
             if length(wvfs_det_dep_pre) > max_wvfs
                 @warn "DEP events exceed $max_wvfs, keep only $max_wvfs events"
-                sel = rand(1:max_wvfs, max_wvfs)
+                sel = sort!(sample(eachindex(wvfs_det_dep_pre), max_wvfs; replace=false))
                 wvfs_det_dep_pre = wvfs_det_dep_pre[sel]
                 wvfs_det_dep_wdw = wvfs_det_dep_wdw[sel]
             end
             # SEP
-            wvfs_det_sep_wdw          = data.Tl208SEP.waveform_windowed[:]
-            wvfs_det_sep_pre          = data.Tl208SEP.waveform_presummed[:]
+            wvfs_det_sep_wdw          = data_sep.waveform_windowed[:]
+            wvfs_det_sep_pre          = data_sep.waveform_presummed[:]
             if length(wvfs_det_sep_pre) > max_wvfs
                 @warn "SEP events exceed $max_wvfs, keep only $max_wvfs events"
-                sel = rand(1:max_wvfs, max_wvfs)
+                sel = sort!(sample(eachindex(wvfs_det_sep_pre), max_wvfs; replace=false))
                 wvfs_det_sep_pre = wvfs_det_sep_pre[sel]
                 wvfs_det_sep_wdw = wvfs_det_sep_wdw[sel]
             end

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -85,11 +85,11 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         wvfs_det = nothing
         try
             @debug "Loading $peakname data from $(part), select $(ifelse(select_random, "randomly", "")) $n_evts events from each run"
-            data = read_ldata(peakname, l200, DataTier(:jlpeaks), :cal, partinfo_det, det; n_evts=n_evts)
-            wvfs_det = getproperty(data, peakname).waveform_presummed[:]
+            data = read_ldata((:waveform_presummed,), l200, DataTier(:jlpeaks), :cal, partinfo_det, det; subgroup=peakname, n_evts=n_evts)
+            wvfs_det = data.waveform_presummed[:]
             if length(wvfs_det) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
-                wvfs_det = wvfs_det[rand(1:max_wvfs, max_wvfs)]
+                wvfs_det = wvfs_det[sort!(sample(eachindex(wvfs_det), max_wvfs; replace=false))]
             end
         catch e
             @error "$peakname data from $(part) cannot be loaded: $(truncate_error(e))"

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -108,14 +108,13 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
         wvfs_det_pre, wvfs_det_wdw, presum_rate = nothing, nothing, nothing
         try
             @debug "Loading $peakname data from $(part), select $(ifelse(select_random, "randomly", "")) $n_evts events from each run"
-            data = read_ldata(peakname, l200, DataTier(:jlpeaks), :cal, partinfo_det, det; n_evts=n_evts)
-            peak_data = getproperty(data, peakname)
+            peak_data = read_ldata((:waveform_presummed, :waveform_windowed, :presum_rate), l200, DataTier(:jlpeaks), :cal, partinfo_det, det; subgroup=peakname, n_evts=n_evts)
             wvfs_det_pre = peak_data.waveform_presummed[:]
             wvfs_det_wdw = peak_data.waveform_windowed[:]
             presum_rate = peak_data.presum_rate[:]
             if length(wvfs_det_pre) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
-                sel = rand(1:max_wvfs, max_wvfs)
+                sel = sort!(sample(eachindex(wvfs_det_pre), max_wvfs; replace=false))
                 wvfs_det_pre = wvfs_det_pre[sel]
                 wvfs_det_wdw = wvfs_det_wdw[sel]
                 presum_rate = presum_rate[sel]

--- a/processors/p_process_skm_phy.jl
+++ b/processors/p_process_skm_phy.jl
@@ -46,13 +46,10 @@ function p_process_skm_phy(processing_config::PropDict, l200::LegendData, period
                 rm(skmfilename, force=true)
             elseif isfile(outfilename)
                 @info "File $(basename(skmfilename)) already exists, skip"
-                n_psd, n_lar, n_larpsd = lh5open(outfilename, "r") do ds
-                    skm_data = ds[:skm][:]
-                    n_psd = mean(skm_data.geds.is_valid_psd) * 100u"percent"
-                    n_lar = mean(skm_data.ged_spm.is_valid_lar) * 100u"percent"
-                    n_larpsd = mean(skm_data.geds.is_valid_psd .&& skm_data.ged_spm.is_valid_lar) * 100u"percent"
-                    n_psd, n_lar, n_larpsd
-                end
+                skm_data = read_ldata(l200, DataTier(:jlskm), fk)
+                n_psd = mean(skm_data.geds.is_valid_psd) * 100u"percent"
+                n_lar = mean(skm_data.ged_spm.is_valid_lar) * 100u"percent"
+                n_larpsd = mean(skm_data.geds.is_valid_psd .&& skm_data.ged_spm.is_valid_lar) * 100u"percent"
                 return (timer = dsp_timer, log = log_nt((fk, ProcessStatus(1), n_larpsd, n_lar, n_psd, "", "", "")), processed = false)
             end
 

--- a/processors/process_aoe_optimization.jl
+++ b/processors/process_aoe_optimization.jl
@@ -82,19 +82,21 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
         
         wvfs_det_sep_wdw, wvfs_det_sep_pre, wvfs_det_dep_wdw, wvfs_det_dep_pre, presum_rate = nothing, nothing, nothing, nothing, nothing
         try
-            peaks = read_ldata(l200, DataTier(:jlpeaks), filekey, det)
-
             @debug "Loading Tl208 SEP and DEP data via read_ldata"
-            wvfs_det_dep_bi121fep_wdw = peaks.Tl208DEP_Bi212FEP.waveform_windowed
-            wvfs_det_dep_bi121fep_pre = peaks.Tl208DEP_Bi212FEP.waveform_presummed
-            presum_rate               = peaks.Tl208SEP.presum_rate[1]
-            e_det_dep_bi121fep        = peaks.Tl208DEP_Bi212FEP.daqenergy
+            # per-peak subgroup reads with column selection: avoids loading every peak
+            # with all waveform variants just to use two of them
+            peaks_dep = read_ldata((:waveform_windowed, :waveform_presummed, :daqenergy), l200, DataTier(:jlpeaks), filekey, det; subgroup=:Tl208DEP_Bi212FEP)
+            peaks_sep = read_ldata((:waveform_windowed, :waveform_presummed, :presum_rate), l200, DataTier(:jlpeaks), filekey, det; subgroup=:Tl208SEP)
+            wvfs_det_dep_bi121fep_wdw = peaks_dep.waveform_windowed
+            wvfs_det_dep_bi121fep_pre = peaks_dep.waveform_presummed
+            presum_rate               = peaks_sep.presum_rate[1]
+            e_det_dep_bi121fep        = peaks_dep.daqenergy
             # wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_det.dep_sep_quantile)]
             wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw
             # wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_det.dep_sep_quantile)]
             wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre
-            wvfs_det_sep_wdw          = peaks.Tl208SEP.waveform_windowed
-            wvfs_det_sep_pre          = peaks.Tl208SEP.waveform_presummed
+            wvfs_det_sep_wdw          = peaks_sep.waveform_windowed
+            wvfs_det_sep_pre          = peaks_sep.waveform_presummed
         catch e
             @error "DEP and SEP data from $(part) cannot be loaded: $(truncate_error(e))"
             throw(LoadError(string(part), 154,"DEP and SEP data from $(part) cannot be loaded: $(truncate_error(e))"))

--- a/processors/process_aoe_optimization.jl
+++ b/processors/process_aoe_optimization.jl
@@ -82,21 +82,19 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
         
         wvfs_det_sep_wdw, wvfs_det_sep_pre, wvfs_det_dep_wdw, wvfs_det_dep_pre, presum_rate = nothing, nothing, nothing, nothing, nothing
         try
-            data = lh5open(filename, "r")
+            peaks = read_ldata(l200, DataTier(:jlpeaks), filekey, det)
 
-            @debug "Loading Tl208 SEP and DEP data from $(filename)"
-            wvfs_det_dep_bi121fep_wdw = data[det].jlpeaks.Tl208DEP_Bi212FEP.waveform_windowed[:]
-            wvfs_det_dep_bi121fep_pre = data[det].jlpeaks.Tl208DEP_Bi212FEP.waveform_presummed[:]
-            presum_rate               = data[det].jlpeaks.Tl208SEP.presum_rate[1]
-            e_det_dep_bi121fep        = data[det].jlpeaks.Tl208DEP_Bi212FEP.daqenergy[:]
+            @debug "Loading Tl208 SEP and DEP data via read_ldata"
+            wvfs_det_dep_bi121fep_wdw = peaks.Tl208DEP_Bi212FEP.waveform_windowed
+            wvfs_det_dep_bi121fep_pre = peaks.Tl208DEP_Bi212FEP.waveform_presummed
+            presum_rate               = peaks.Tl208SEP.presum_rate[1]
+            e_det_dep_bi121fep        = peaks.Tl208DEP_Bi212FEP.daqenergy
             # wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_det.dep_sep_quantile)]
             wvfs_det_dep_wdw          = wvfs_det_dep_bi121fep_wdw
             # wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre[e_det_dep_bi121fep .< quantile(e_det_dep_bi121fep, aoe_config_det.dep_sep_quantile)]
             wvfs_det_dep_pre          = wvfs_det_dep_bi121fep_pre
-            wvfs_det_sep_wdw          = data[det].jlpeaks.Tl208SEP.waveform_windowed[:]
-            wvfs_det_sep_pre          = data[det].jlpeaks.Tl208SEP.waveform_presummed[:]
-
-            close(data)
+            wvfs_det_sep_wdw          = peaks.Tl208SEP.waveform_windowed
+            wvfs_det_sep_pre          = peaks.Tl208SEP.waveform_presummed
         catch e
             @error "DEP and SEP data from $(part) cannot be loaded: $(truncate_error(e))"
             throw(LoadError(string(part), 154,"DEP and SEP data from $(part) cannot be loaded: $(truncate_error(e))"))

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -68,10 +68,8 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
         # load data
         wvfs_det = nothing
         try
-            data = lh5open(filename, "r")
-            @debug "Loading $peakname data from $(filename)"
-            wvfs_det = data[det, :jlpeaks, peakname].waveform_presummed[:]
-            close(data)
+            @debug "Loading $peakname data via read_ldata"
+            wvfs_det = read_ldata(l200, DataTier(:jlpeaks), filekey, det)[peakname].waveform_presummed
             if length(wvfs_det) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
                 sel = rand(1:max_wvfs, max_wvfs)

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -69,12 +69,8 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
         wvfs_det = nothing
         try
             @debug "Loading $peakname data via read_ldata"
-            wvfs_det = read_ldata(l200, DataTier(:jlpeaks), filekey, det)[peakname].waveform_presummed
-            if length(wvfs_det) > max_wvfs
-                @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
-                sel = rand(1:max_wvfs, max_wvfs)
-                wvfs_det = wvfs_det[sel]
-            end
+            # load only the needed column of the needed peak; n_evts caps to a random subsample
+            wvfs_det = read_ldata((:waveform_presummed,), l200, DataTier(:jlpeaks), filekey, det; subgroup=peakname, n_evts=max_wvfs).waveform_presummed
         catch e
             @error "$peakname data from $(basename(filename)) cannot be loaded: $(truncate_error(e))"
             throw(LoadError(string(basename(filename)), 154,"$peakname data from $(basename(filename)) cannot be loaded: $(truncate_error(e))"))

--- a/processors/process_evt_phy.jl
+++ b/processors/process_evt_phy.jl
@@ -29,65 +29,58 @@ function process_evt_phy(processing_config::PropDict, l200::LegendData, period::
         # number of forced, pulser and physical triggers
         n_forced, n_pulser, n_phy = 0, 0, 0
         # start processing
-        read_files(dspfilename, use_cache = false) do filename
-            write_files(evtfilename, use_cache = true, mode = CreateOrModify()) do outfilename
+        write_files(evtfilename, use_cache = true, mode = CreateOrModify()) do outfilename
                 if reprocess && isfile(outfilename)
                     @info "Reprocess $(basename(evtfilename)), remove old Evt."
                     rm(outfilename, force=true)
                     rm(evtfilename, force=true)
                 elseif isfile(outfilename)
                     @info "File $(basename(evtfilename)) already exists, skip"
-                    n_forced, n_pulser, n_phy = lh5open(outfilename, "r") do ds
-                        evt_data = ds[:jlevt][:]
-                        n_forced = count(evt_data.aux.forcedtrigger.aux_trig)
-                        n_pulser = count(evt_data.aux.pulser.aux_trig)
-                        n_phy = count(evt_data.geds.is_valid_qc .&& length.(evt_data.geds.trig_e_det) .> 1)
-                        n_forced, n_pulser, n_phy
-                    end
+                    evt_data = read_ldata(l200, DataTier(:jlevt), fk)
+                    n_forced = count(evt_data.aux.forcedtrigger.aux_trig)
+                    n_pulser = count(evt_data.aux.pulser.aux_trig)
+                    n_phy = count(evt_data.geds.is_valid_qc .&& length.(evt_data.geds.trig_e_det) .> 1)
                     return (timer = dsp_timer, log = log_nt((fk, ProcessStatus(1), n_phy, n_forced, n_pulser, "", "", "")), processed = false)
                 end
 
                 # open output file
                 @timeit dsp_timer "Evt" begin
-                    n_forced, n_pulser, n_phy = lh5open(filename, "r") do dsp_data
-                        # generate evt level table
-                        out_t, pmts_out_t = nothing, nothing
-                        try 
-                            out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data)
-                        catch e
-                            @error "Error processing $fk: $(truncate_error(e))"
-                            throw(ErrorException("Error processing $fk: $(truncate_error(e))"))
-                        end
-                        # get number of forced, physical and pulser triggers
-                        n_forced = count(out_t.aux.forcedtrigger.aux_trig)
-                        @debug "Number of forced triggers: $n_forced"
-                        n_pulser = count(out_t.aux.pulser.aux_trig)
-                        @debug "Number of pulser triggers: $n_pulser"
-                        n_phy = count(out_t.geds.is_valid_qc .&& length.(out_t.geds.trig_e_det) .> 1)
-                        @debug "Number of physical triggers: $n_phy"
-                        lh5open(outfilename, "cw") do ds
-                            ds[:jlevt] = out_t
-                        end
-                        # write pmt evt file
-                        if !isempty(pmts_out_t)
-                            write_files(pmtevtfilename, use_cache = true, mode = CreateOrModify()) do pmtoutfilename
-                                # Remove cached PMT file if reprocess is enabled
-                                if reprocess && isfile(pmtoutfilename)
-                                    @info "Reprocess $(basename(pmtevtfilename)), remove old PMT."
-                                    rm(pmtoutfilename, force=true)
-                                    rm(pmtevtfilename, force=true)
-                                end
-                                lh5open(pmtoutfilename, "cw") do ds
-                                    ds[:jlpmt] = pmts_out_t
-                                end
+                    # generate evt level table
+                    dsp_data = read_ldata(l200, DataTier(:jldsp), fk)
+                    out_t, pmts_out_t = nothing, nothing
+                    try 
+                        out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data)
+                    catch e
+                        @error "Error processing $fk: $(truncate_error(e))"
+                        throw(ErrorException("Error processing $fk: $(truncate_error(e))"))
+                    end
+                    # get number of forced, physical and pulser triggers
+                    n_forced = count(out_t.aux.forcedtrigger.aux_trig)
+                    @debug "Number of forced triggers: $n_forced"
+                    n_pulser = count(out_t.aux.pulser.aux_trig)
+                    @debug "Number of pulser triggers: $n_pulser"
+                    n_phy = count(out_t.geds.is_valid_qc .&& length.(out_t.geds.trig_e_det) .> 1)
+                    @debug "Number of physical triggers: $n_phy"
+                    lh5open(outfilename, "cw") do ds
+                        ds[:jlevt] = out_t
+                    end
+                    # write pmt evt file
+                    if !isempty(pmts_out_t)
+                        write_files(pmtevtfilename, use_cache = true, mode = CreateOrModify()) do pmtoutfilename
+                            # Remove cached PMT file if reprocess is enabled
+                            if reprocess && isfile(pmtoutfilename)
+                                @info "Reprocess $(basename(pmtevtfilename)), remove old PMT."
+                                rm(pmtoutfilename, force=true)
+                                rm(pmtevtfilename, force=true)
+                            end
+                            lh5open(pmtoutfilename, "cw") do ds
+                                ds[:jlpmt] = pmts_out_t
                             end
                         end
-                        n_forced, n_pulser, n_phy
                     end
                 end
                 
                 @info "Finished processing $(basename(evtfilename))"
-            end
         end
 
         # create total timer by summing over memory usage and time

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -85,12 +85,11 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
         # load data
         wvfs_det_pre, wvfs_det_wdw, presum_rate = nothing, nothing, nothing
         try
-            data = lh5open(filename, "r")
-            @debug "Loading Tl208 FEP data from $(filename)"
-            wvfs_det_pre = data[det, :jlpeaks, peakname].waveform_presummed[:]
-            wvfs_det_wdw = data[det, :jlpeaks, peakname].waveform_windowed[:]
-            presum_rate = data[det, :jlpeaks, peakname].presum_rate[:]
-            close(data)
+            @debug "Loading $peakname data via read_ldata"
+            peak_data = read_ldata(l200, DataTier(:jlpeaks), filekey, det)[peakname]
+            wvfs_det_pre = peak_data.waveform_presummed
+            wvfs_det_wdw = peak_data.waveform_windowed
+            presum_rate = peak_data.presum_rate
             if length(wvfs_det_pre) > max_wvfs
                 @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
                 sel = rand(1:max_wvfs, max_wvfs)

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -86,17 +86,12 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
         wvfs_det_pre, wvfs_det_wdw, presum_rate = nothing, nothing, nothing
         try
             @debug "Loading $peakname data via read_ldata"
-            peak_data = read_ldata(l200, DataTier(:jlpeaks), filekey, det)[peakname]
+            # load only the needed columns of the needed peak; n_evts caps to a random
+            # subsample with one shared row index, so the columns stay aligned
+            peak_data = read_ldata((:waveform_presummed, :waveform_windowed, :presum_rate), l200, DataTier(:jlpeaks), filekey, det; subgroup=peakname, n_evts=max_wvfs)
             wvfs_det_pre = peak_data.waveform_presummed
             wvfs_det_wdw = peak_data.waveform_windowed
             presum_rate = peak_data.presum_rate
-            if length(wvfs_det_pre) > max_wvfs
-                @warn "$peakname events exceed $max_wvfs, keep only $max_wvfs events"
-                sel = rand(1:max_wvfs, max_wvfs)
-                wvfs_det_pre = wvfs_det_pre[sel]
-                wvfs_det_wdw = wvfs_det_wdw[sel]
-                presum_rate = presum_rate[sel]
-            end
         catch e
             @error "$peakname data from $(basename(filename)) cannot be loaded: $(truncate_error(e))"
             throw(LoadError(string(basename(filename)), 154,"$peakname data from $(basename(filename)) cannot be loaded: $(truncate_error(e))"))

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -45,7 +45,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         pulserfilename = l200.tier[:jlpls, filekey, det_puls]
 
         if !reprocess && isfile(pulserfilename)
-            return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(lh5open(pulserfilename)[det_puls, :jlpls, :tags]), "Already processed --> skipped.")))
+            return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(read_ldata(l200, DataTier(:jlpls), filekey, det_puls; subgroup=:tags)), "Already processed --> skipped.")))
         end
         # extract pulser events by loading data from raw files (filtered by bad_filekeys)
         @info "Get pulser events from raw data"
@@ -127,7 +127,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         try
             @debug "Get Pulser tags"
             # pulser_tag = pulser_cal_qc(data_det, pulser_config_det; n_pulser_identified=100)
-            data_pulser = lh5open(pulserfilename)[det_puls, :jlpls, :tags][:]
+            data_pulser = read_ldata(l200, DataTier(:jlpls), filekey, det_puls; subgroup=:tags)
             is_pulser = flag_coincidences(data_det.timestamp, data_pulser.timestamp, ts_window = pulser_config_det.puls_ts_window)
             @debug "Found $(count(is_pulser)) pulser events"
         catch e

--- a/processors/process_peak_split.jl
+++ b/processors/process_peak_split.jl
@@ -33,22 +33,8 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
 
     @info "Expecting $(length(detectors)) detectors each file in \"$input_datadir\"."
 
-    function get_daqenergy_for_det(filelist::AbstractVector{<:AbstractString}, det::DetectorId)
-        fast_flatten([
-            LHDataStore(
-                ds -> begin
-                    @debug "Reading DAQ energy for detector $det from \"$(ds.data_store.filename)\""
-                    ds[det].raw.daqenergy[:]
-                end,
-                filename
-            ) for filename in filelist
-        ])
-    end
-
-    function channels_in_file(filename)
-        LHDataStore(filename) do ds
-            sort(chname2int.(filter(startswith("ch"), keys(ds))))
-        end
+    function get_daqenergy_for_det(keys::AbstractVector{FileKey}, det::DetectorId)
+        fast_flatten([read_ldata(:daqenergy, l200, DataTier(:raw), fk, det).daqenergy for fk in keys])
     end
 
     # get keylists and check files
@@ -140,17 +126,15 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
 
         energy_windows = IdDict(keys(raw_config_det.peaks) .=> [first(v)..last(v) for v in values(raw_config_det.peaks)])
 
-        filelist = [l200.tier[:raw, key] for key in filekeys]
         output_filename = l200.tier[:jlpeaks, first(filekeys), det]
 
         if isfile(output_filename) && !reprocess
             @info "Output file \"$output_filename\" already exists, skipping"
             n_sep, n_fep = nothing, nothing
             try
-                output = lh5open(output_filename, "r")
-                n_sep = length(output[det].jlpeaks.Tl208SEP.daqenergy)
-                n_fep = length(output[det].jlpeaks.Tl208FEP.daqenergy)
-                close(output)
+                output_data = read_ldata(l200, DataTier(:jlpeaks), first(filekeys), det)
+                n_sep = length(output_data.Tl208SEP.daqenergy)
+                n_fep = length(output_data.Tl208FEP.daqenergy)
             catch e
                 @error "Error reading SEP and FEP events from $(basename(output_filename)): $(truncate_error(e))"
                 @warn "Filename $(basename(output_filename)) seems broken, remove it."
@@ -168,7 +152,7 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
         @timeit split_timer "$det" begin
             # get raw daqenergy
             @timeit split_timer "Get DAQ Energy" begin
-                e_raw = get_daqenergy_for_det(filelist, det)
+                e_raw = get_daqenergy_for_det(filekeys, det)
                 @info "Auto calibrating $det ($ch)"
                 result_autocal, report_autocal = autocal_energy(e_raw, raw_config_det.th228_cal_lines; mode=:ratio, min_e=raw_config_det.min_e, max_e=raw_config_det.max_e, max_e_binning_quantile=raw_config_det.max_e_binning_quantile, σ=raw_config_det.σ, threshold=raw_config_det.threshold, min_n_peaks=raw_config_det.min_n_peaks, max_n_peaks=raw_config_det.max_n_peaks, α=raw_config_det.α, rtol=raw_config_det.rtol)
                 f_calib = result_autocal.f_calib
@@ -178,11 +162,10 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
             GC.gc()
             @info "Filtering detector $det ($ch)"
             @timeit split_timer "Filter Raw" begin
-                slim_data = flatten_by_key([lh5open(filename) do ds
-                    @debug "Filtering $(filename) for detector $det ($ch)"
-                    filter_raw_data_by_energy(ds[det].raw[:], f_calib, energy_windows; chunk_size=100)
-                    # filter_raw_data_by_energy(Table(decode_data(ds[det].raw[:])), f_calib, energy_windows)
-                end for filename in filelist])
+                slim_data = flatten_by_key([begin
+                    @debug "Filtering filekey $(key) for detector $det ($ch)"
+                    filter_raw_data_by_energy(read_ldata(l200, DataTier(:raw), key, det), f_calib, energy_windows; chunk_size=100)
+                end for key in filekeys])
             end
             n_fep = length(slim_data[:Tl208FEP].daqenergy)
             n_sep = length(slim_data[:Tl208SEP].daqenergy)
@@ -196,7 +179,7 @@ function process_peak_split(processing_config::PropDict, l200::LegendData, perio
                 write_files(output_filename, use_cache = false, mode = CreateOrReplace()) do outfile
                     lh5open(outfile, "w") do output
                         for label in sort(collect(keys(slim_data)))
-                            output[det, :jlpeaks, label] = slim_data[label]
+                            output[:jlpeaks, det, label] = slim_data[label]
                             # output[det, :jlpeaks, label] = decode_data(slim_data[label])
                         end
                     end


### PR DESCRIPTION
## What didn't work before
Several processors opened their input tier files directly with `lh5open(...)` and
indexed into them by hand. That ties each processor to the on-disk file layout and
to channel-based indexing, and duplicates file-handling logic everywhere.

## Why the change is necessary
`read_ldata` (LegendDataManagement) is now the single, layout-aware way to read tier
data **by DetectorId** — it resolves the `<tier>/<det>` layout, selects columns, and
filters. Moving the processors onto it removes the per-processor file handling and
makes them robust to the layout migration.

## What works now
- The skm, AoE-optimization, decay-time, evt, filter-optimization and peak-split
  processors read their input via `read_ldata` instead of `lh5open`.
- `process_hit_cal` reads the pulser tags via `read_ldata(…, :jlpls, …; subgroup=:tags)`
  (the new sub-group feature).
- Reads are now by `DetectorId` and layout-agnostic — no manual tier-file handling.

## Dependencies
Pure read-side change — no output-format change (that is the `output-tier-det` PR).
Requires the LegendDataManagement read_ldata work (DetectorId API → path resolver +
`subgroup` → event-tier reads). Independent of the other Juleana PRs (shares
`process_hit_cal.jl` with `output-tier-det`, but on different lines).


## Since the first version
jlpeaks reads in the decay-time / filter- / A/E-optimization processors (run and period
level) now use `subgroup = :<peak>` plus column selection instead of loading the whole
per-detector jlpeaks table — needs the read_ldata `subgroup` kwarg (LDM PR2) and shared-index
`n_evts` sampling (LDM PR3).
