### PR TITLE
processors: write all tier outputs as tier/DetectorID

### DIFF
--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -94,8 +94,8 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
 
             # open output file
             outdata = lh5open(outfilename, "cw")
-            # get processed detectors
-            processed_channels = haskey(outdata, "jldsp") ? keys(outdata["jldsp"]) : String[]
+            # get processed detectors (keys of the group are Symbols, compare as String)
+            processed_channels = haskey(outdata, "jldsp") ? string.(keys(outdata["jldsp"])) : String[]
 
             @info "Start DSP"
             @timeit dsp_timer "DSP" begin

--- a/processors/process_dsp_cal.jl
+++ b/processors/process_dsp_cal.jl
@@ -84,99 +84,95 @@ function process_dsp_cal(processing_config::PropDict, l200::LegendData, period::
         # detector ids of failed detectors
         failed_detectors = DetectorId[]
         # start processing
-        read_files(rawfilename, use_cache = false) do filename
-            write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
-                @timeit dsp_timer "Startup" begin
-                    raw_data = lh5open(filename, "r")
-                    if reprocess && isfile(dspfilename)
-                        @info "Reprocess $(basename(dspfilename)), remove old DSP."
-                        rm(outfilename, force=true)
-                    end
+        write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
+            @timeit dsp_timer "Startup" begin
+                if reprocess && isfile(dspfilename)
+                    @info "Reprocess $(basename(dspfilename)), remove old DSP."
+                    rm(outfilename, force=true)
                 end
-
-                # open output file
-                outdata = lh5open(outfilename, "cw")
-                # get processed detectors
-                processed_channels = keys(outdata)
-
-                @info "Start DSP"
-                @timeit dsp_timer "DSP" begin
-                    # loop over detectors
-                    @showprogress desc="Filekey: $fk" output=stdout for chinfo_det in chinfo
-                        
-                        ch = chinfo_det.channel
-                        det = chinfo_det.detector
-
-                        dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
-                        dsp_config_det = DSPConfig(dsp_config_pd_det)
-                        @debug "Loaded DSP config: $(lstring(dsp_config_det))"
-
-                        # check if channel can be processed
-                        if "$det" in processed_channels && !reprocess
-                            @info "Detector $det ($ch) already processed, skip"
-                            n_detectors += 1
-                            continue
-                        end
-                        
-                        # check for decay time
-                        if !haskey(pars_tau, det)
-                            @warn "No decay time for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-                        # check if channel has values for RT and FT for different filters
-                        if !haskey(pars_fltoptimization, det)
-                            @warn "No optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if channel has all required flt opt pars
-                        if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
-                            @warn "Not all required energy filter optimization parameters available for detector $det, skip"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if channel has all required aoe opt pars
-                        if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
-                            @warn "Not all required A/E optimization parameters available for detector $det, skip"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        @debug "Processing detector $det ($ch)"
-                        @timeit dsp_timer "DSP $det" begin
-                            # process data
-                            outdata_det = nothing
-                            try
-                                outdata_det = dsp_icpc_compressed(raw_data[det].raw[:], dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
-                            catch e
-                                if e isa TaskFailedException
-                                    e = e.task.exception
-                                end
-                                @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                push!(failed_detectors, det)
-                                continue
-                            end
-                            # save data to hdf5
-                            outdata[det, :jldsp] = outdata_det
-                            # free memory
-                            GC.gc()
-                            # count number of detectors processed and Successful
-                            n_detectors += 1
-                            # flush streams
-                            flush(stdout)
-                            flush(stderr)
-                        end
-                    end
-                    # close outdata file
-                    close(outdata)
-                end
-                @info "Finished processing file: $(basename(rawfilename))"
-                close(raw_data)
-                # return number of processed detectors and failed detectors
             end
+
+            # open output file
+            outdata = lh5open(outfilename, "cw")
+            # get processed detectors
+            processed_channels = haskey(outdata, "jldsp") ? keys(outdata["jldsp"]) : String[]
+
+            @info "Start DSP"
+            @timeit dsp_timer "DSP" begin
+                # loop over detectors
+                @showprogress desc="Filekey: $fk" output=stdout for chinfo_det in chinfo
+                    
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+
+                    dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
+                    dsp_config_det = DSPConfig(dsp_config_pd_det)
+                    @debug "Loaded DSP config: $(lstring(dsp_config_det))"
+
+                    # check if channel can be processed
+                    if "$det" in processed_channels && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+                    
+                    # check for decay time
+                    if !haskey(pars_tau, det)
+                        @warn "No decay time for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+                    # check if channel has values for RT and FT for different filters
+                    if !haskey(pars_fltoptimization, det)
+                        @warn "No optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if channel has all required flt opt pars
+                    if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
+                        @warn "Not all required energy filter optimization parameters available for detector $det, skip"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if channel has all required aoe opt pars
+                    if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
+                        @warn "Not all required A/E optimization parameters available for detector $det, skip"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # process data
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_icpc_compressed(read_ldata(l200, DataTier(:raw), fk, det), dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+                # close outdata file
+                close(outdata)
+            end
+            @info "Finished processing file: $(basename(rawfilename))"
+            # return number of processed detectors and failed detectors
         end
         if n_detectors == 0
             @warn "No detectors processed in $(basename(rawfilename))"

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -104,8 +104,8 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
 
             # open output file
             outdata = lh5open(outfilename, "cw")
-            # get processed detectors
-            processed_detectors = haskey(outdata, "jldsp") ? keys(outdata["jldsp"]) : String[]
+            # get processed detectors (keys of the group are Symbols, compare as String)
+            processed_detectors = haskey(outdata, "jldsp") ? string.(keys(outdata["jldsp"])) : String[]
 
             @info "Start DSP"
             @timeit dsp_timer "DSP" begin

--- a/processors/process_dsp_phy.jl
+++ b/processors/process_dsp_phy.jl
@@ -94,160 +94,25 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
         # detector ids of failed detectors
         failed_detectors = DetectorId[]
         # start processing
-        read_files(rawfilename, use_cache = false) do filename
-            write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
-                @timeit dsp_timer "Startup" begin
-                    raw_data = lh5open(filename, "r")
-                    if reprocess && isfile(outfilename)
-                        @info "Reprocess $(basename(outfilename)), remove old DSP."
-                        rm(outfilename, force=true)
-                    end
+        write_files(dspfilename, use_cache = true, mode = CreateOrModify()) do outfilename
+            @timeit dsp_timer "Startup" begin
+                if reprocess && isfile(outfilename)
+                    @info "Reprocess $(basename(outfilename)), remove old DSP."
+                    rm(outfilename, force=true)
                 end
+            end
 
-                # open output file
-                outdata = lh5open(outfilename, "cw")
-                # get processed detectors
-                processed_detectors = keys(outdata)
+            # open output file
+            outdata = lh5open(outfilename, "cw")
+            # get processed detectors
+            processed_detectors = haskey(outdata, "jldsp") ? keys(outdata["jldsp"]) : String[]
 
-                @info "Start DSP"
-                @timeit dsp_timer "DSP" begin
-                    if haskey(dsp_config_pd, :additional_detectors)
-                        # process additional detectors
-                        for det in DetectorId.(keys(dsp_config_pd.additional_detectors))
-                            ch = channelinfo(l200, filekey, det).channel
-
-                            dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
-                            dsp_config_det = DSPConfig(dsp_config_pd_det)
-                            @debug "Loaded DSP config: $(lstring(dsp_config_det))"
-
-                            # check if detector can be processed
-                            if "$det" in processed_detectors && !reprocess
-                                @info "Detector $det ($ch) already processed, skip"
-                                n_detectors += 1
-                                continue
-                            end
-
-                            @debug "Processing detector $det ($ch)"
-                            @timeit dsp_timer "DSP $det" begin
-                                # process data
-                                outdata_det = nothing
-                                try
-                                    outdata_det = getfield(LegendDSP, Symbol(dsp_config_pd.additional_detectors[Symbol(det)]))(raw_data[det].raw[:], dsp_config_det)
-                                catch e
-                                    if e isa TaskFailedException
-                                        e = e.task.exception
-                                    end
-                                    @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                    push!(failed_detectors, det)
-                                    continue
-                                end
-                                # save data to hdf5
-                                outdata[det, :jldsp] = outdata_det
-                                # free memory
-                                GC.gc()
-                                # count number of detectors processed and Successful
-                                n_detectors += 1
-                            end
-                        end
-                    end
-
-                    # loop over detectors
-                    if all(.!haskey.(Ref(raw_data), string.(chinfo_pmts.detector)))
-                        @warn "No PMT data found in $(fk), skip PMT processing"
-                        n_detectors += length(chinfo_pmts)
-                    else
-                        @showprogress desc="Filekey PMTS: $fk" output=stdout for chinfo_det in chinfo_pmts
-
-                            ch = chinfo_det.channel
-                            det = chinfo_det.detector
-            
-                            # check if detector can be processed
-                            if "$det" in processed_detectors && !reprocess
-                                @info "Detector $det ($ch) already processed, skip"
-                                n_detectors += 1
-                                continue
-                            end
-            
-                            @debug "Processing detector $det ($ch)"
-                            @timeit dsp_timer "DSP $det" begin
-                                # get metadata
-                                dsp_meta_det = merge(dsp_meta_pmt.default, get(dsp_meta_pmt, det, PropDict()))
-                                # process detector
-                                outdata_det = nothing
-                                try
-                                    outdata_det = dsp_pmts(raw_data[det].raw[:], dsp_meta_det)
-                                catch e
-                                    if e isa TaskFailedException
-                                        e = e.task.exception
-                                    end
-                                    @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                    push!(failed_detectors, det)
-                                    continue
-                                end
-                                # save data to hdf5
-                                outdata[det, :jldsp] = outdata_det
-                                # free memory
-                                GC.gc()
-                                # count number of detectors processed and Successful
-                                n_detectors += 1
-                                # flush streams
-                                flush(stdout)
-                                flush(stderr)
-                            end
-                        end
-                    end
-
-                    # loop over detectors
-                    @showprogress desc="Filekey SiPM: $fk" output=stdout for chinfo_det in chinfo_sipm
-
-                        ch = chinfo_det.channel
-                        det = chinfo_det.detector
-        
-                        # check if detector can be processed
-                        if !haskey(pars_sipm, det)
-                            @warn "No thresholds for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-                        if "$det" in processed_detectors && !reprocess
-                            @info "Detector $det ($ch) already processed, skip"
-                            n_detectors += 1
-                            continue
-                        end
-        
-                        @debug "Processing detector $det ($ch)"
-                        @timeit dsp_timer "DSP $det" begin
-                            # get metadata
-                            dsp_meta_det = merge(dsp_meta_sipm.default, get(dsp_meta_sipm, det, PropDict()))
-                            # process detector
-                            outdata_det = nothing
-                            try
-                                outdata_det = dsp_sipm_compressed(raw_data[det].raw[:], dsp_meta_det, pars_sipm[det])
-                            catch e
-                                if e isa TaskFailedException
-                                    e = e.task.exception
-                                end
-                                @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
-                                push!(failed_detectors, det)
-                                continue
-                            end
-                            # save data to hdf5
-                            outdata[det, :jldsp] = outdata_det
-                            # free memory
-                            GC.gc()
-                            # count number of detectors processed and Successful
-                            n_detectors += 1
-                            # flush streams
-                            flush(stdout)
-                            flush(stderr)
-                        end
-                    end
-
-                    # loop over detectors
-                    @showprogress desc="Filekey HPGe: $fk" output=stdout for chinfo_det in chinfo
-
-                        ch = chinfo_det.channel
-                        det = chinfo_det.detector
+            @info "Start DSP"
+            @timeit dsp_timer "DSP" begin
+                if haskey(dsp_config_pd, :additional_detectors)
+                    # process additional detectors
+                    for det in DetectorId.(keys(dsp_config_pd.additional_detectors))
+                        ch = channelinfo(l200, filekey, det).channel
 
                         dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
                         dsp_config_det = DSPConfig(dsp_config_pd_det)
@@ -260,39 +125,12 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                             continue
                         end
 
-                        # check for decay time
-                        if !haskey(pars_tau, det)
-                            @warn "No decay time for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-                        # check if detector has values for RT and FT for different filters
-                        if !haskey(pars_fltoptimization, det)
-                            @warn "No optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if detector has all required flt opt pars
-                        if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
-                            @warn "Not all required energy filter optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
-                        # check if detector has all required aoe opt pars
-                        if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
-                            @warn "Not all required A/E optimization parameters for detector $det, skip detector $ch"
-                            push!(failed_detectors, det)
-                            continue
-                        end
-
                         @debug "Processing detector $det ($ch)"
                         @timeit dsp_timer "DSP $det" begin
                             # process data
                             outdata_det = nothing
                             try
-                                outdata_det = dsp_icpc_compressed(raw_data[det].raw[:], dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
+                                outdata_det = getfield(LegendDSP, Symbol(dsp_config_pd.additional_detectors[Symbol(det)]))(read_ldata(l200, DataTier(:raw), fk, det), dsp_config_det)
                             catch e
                                 if e isa TaskFailedException
                                     e = e.task.exception
@@ -302,25 +140,178 @@ function process_dsp_phy(processing_config::PropDict, l200::LegendData, period::
                                 continue
                             end
                             # save data to hdf5
-                            outdata[det, :jldsp] = outdata_det
+                            outdata[:jldsp, det] = outdata_det
                             # free memory
                             GC.gc()
                             # count number of detectors processed and Successful
                             n_detectors += 1
-                            # flush streams
-                            flush(stdout)
-                            flush(stderr)
                         end
                     end
-                    # close outdata file
-                    close(outdata)
                 end
-                @info "Finished processing file: $(basename(filename))"
-                close(raw_data)
+
+                # loop over PMT detectors
+                @showprogress desc="Filekey PMTS: $fk" output=stdout for chinfo_det in chinfo_pmts
+
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+
+                    # check if detector can be processed
+                    if "$det" in processed_detectors && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # get metadata
+                        dsp_meta_det = merge(dsp_meta_pmt.default, get(dsp_meta_pmt, det, PropDict()))
+                        # process detector
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_pmts(read_ldata(l200, DataTier(:raw), fk, det), dsp_meta_det)
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+
+                # loop over SiPM detectors
+                @showprogress desc="Filekey SiPM: $fk" output=stdout for chinfo_det in chinfo_sipm
+
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+    
+                    # check if detector can be processed
+                    if !haskey(pars_sipm, det)
+                        @warn "No thresholds for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+                    if "$det" in processed_detectors && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+    
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # get metadata
+                        dsp_meta_det = merge(dsp_meta_sipm.default, get(dsp_meta_sipm, det, PropDict()))
+                        # process detector
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_sipm_compressed(read_ldata(l200, DataTier(:raw), fk, det), dsp_meta_det, pars_sipm[det])
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+
+                # loop over HPGe detectors
+                @showprogress desc="Filekey HPGe: $fk" output=stdout for chinfo_det in chinfo
+
+                    ch = chinfo_det.channel
+                    det = chinfo_det.detector
+
+                    dsp_config_pd_det = merge(dsp_config_pd.default, get(dsp_config_pd, det, PropDict()))
+                    dsp_config_det = DSPConfig(dsp_config_pd_det)
+                    @debug "Loaded DSP config: $(lstring(dsp_config_det))"
+
+                    # check if detector can be processed
+                    if "$det" in processed_detectors && !reprocess
+                        @info "Detector $det ($ch) already processed, skip"
+                        n_detectors += 1
+                        continue
+                    end
+
+                    # check for decay time
+                    if !haskey(pars_tau, det)
+                        @warn "No decay time for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+                    # check if detector has values for RT and FT for different filters
+                    if !haskey(pars_fltoptimization, det)
+                        @warn "No optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if detector has all required flt opt pars
+                    if !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_fltopt)))
+                        @warn "Not all required energy filter optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    # check if detector has all required aoe opt pars
+                    if chinfo_det.usability == :on && chinfo_det.low_aoe_status in [:valid, :present] && !all(haskey.(Ref(pars_fltoptimization[det]), Symbol.(dsp_config_pd_det.required_aoeopt)))
+                        @warn "Not all required A/E optimization parameters for detector $det, skip detector $ch"
+                        push!(failed_detectors, det)
+                        continue
+                    end
+
+                    @debug "Processing detector $det ($ch)"
+                    @timeit dsp_timer "DSP $det" begin
+                        # process data
+                        outdata_det = nothing
+                        try
+                            outdata_det = dsp_icpc_compressed(read_ldata(l200, DataTier(:raw), fk, det), dsp_config_det, pars_tau[det].τ, pars_fltoptimization[det]; f_evaluate_qc=f_evaluate_qc)
+                        catch e
+                            if e isa TaskFailedException
+                                e = e.task.exception
+                            end
+                            @error "Error processing detector $det ($ch) in $(fk): $(truncate_error(e))"
+                            push!(failed_detectors, det)
+                            continue
+                        end
+                        # save data to hdf5
+                        outdata[:jldsp, det] = outdata_det
+                        # free memory
+                        GC.gc()
+                        # count number of detectors processed and Successful
+                        n_detectors += 1
+                        # flush streams
+                        flush(stdout)
+                        flush(stderr)
+                    end
+                end
+                # close outdata file
+                close(outdata)
             end
+            @info "Finished processing file: $(basename(rawfilename))"
         end
         if n_detectors == 0
-            @warn "No detectors processed in $(basename(filename))"
+            @warn "No detectors processed in $(basename(rawfilename))"
         end
 
         # create total timer by summing over memory usage and time

--- a/processors/process_hit_cal.jl
+++ b/processors/process_hit_cal.jl
@@ -55,7 +55,7 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         write_files(pulserfilename, use_cache=true, mode = CreateOrReplace()) do outfilename
             lh5open(outfilename, "w") do outdata
                 @info "Save Pulser Tags"
-                outdata[det_puls, :jlpls, :tags] = data_puls;
+                outdata[:jlpls, det_puls, :tags] = data_puls;
             end
         end
         return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(data_puls), "-")))
@@ -159,13 +159,13 @@ function process_hit_cal(processing_config::PropDict, l200::LegendData, period::
         write_files(hitdetfilename, use_cache = true, mode = CreateOrReplace()) do outfilename
             lh5open(outfilename, "w") do outdata
                 @info "Save QC"
-                outdata[det, :jlhit, :qc] = Table(merge(columns(qc), (is_physical = is_physical,)));
+                outdata[:jlhit, det, :qc] = Table(merge(columns(qc), (is_physical = is_physical,)));
                 @info "Save Pulser Tags"
-                outdata[det, :jlhit, :pulserTag] = is_pulser;
+                outdata[:jlhit, det, :pulserTag] = is_pulser;
                 @info "Save data after QC"
-                outdata[det, :jlhit, :dataQC] = data_det_after_qc;
+                outdata[:jlhit, det, :dataQC] = data_det_after_qc;
                 @info "Save data pulser"
-                outdata[det, :jlhit, :dataPulser] = data_pulser;
+                outdata[:jlhit, det, :dataPulser] = data_pulser;
             end
         end
 

--- a/processors/process_sipm_optimization_phy.jl
+++ b/processors/process_sipm_optimization_phy.jl
@@ -50,7 +50,7 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         pulserfilename = l200.tier[:jlpls, filekey, det_puls]
 
         if !reprocess && isfile(pulserfilename)
-            return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(lh5open(pulserfilename)[det_puls, :jlpls, :tags]), "Already processed --> skipped.")))
+            return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(read_ldata(l200, DataTier(:jlpls), filekey, det_puls)), "Already processed --> skipped.")))
         end
         # extract pulser events by loading data from raw files
         @info "Get pulser events from raw data"
@@ -73,7 +73,7 @@ function process_sipm_optimization_phy(processing_config::PropDict, l200::Legend
         write_files(pulserfilename, use_cache=true, mode = CreateOrReplace()) do outfilename
             lh5open(outfilename, "w") do outdata
                 @info "Save Pulser Tags"
-                outdata[det_puls, :jlpls, :tags] = data_puls;
+                outdata[:jlpls, det_puls, :tags] = data_puls;
             end
         end
         return (processed = false, log = log_nt_puls((det_puls, ch_puls, ProcessStatus(1), length(data_puls), "Already processed --> skipped.")))


### PR DESCRIPTION
## What didn't work before
Processors wrote each detector's tier output as `<det>/<tier>` (e.g.
`outdata[det, :jldsp]`, `outdata[det, :jlhit, …]`) — the old layout.

## Why the change is necessary
We're standardizing **all** tier outputs to `<tier>/<det>` — for consistency, and
because reading `<tier>/<det>` (e.g. `raw/<det>`) is faster than `<det>/<tier>`. This
is the **writer side** of the LegendDataManagement path resolver, which reads the new
layout.

## What works now
- `jldsp` is written as `outdata[:jldsp, det]` (DSP cal/phy + sipm-optimization).
- `jlhit` / `jlpls` are written as `outdata[:jlhit, det, …]` / `outdata[:jlpls, det, :tags]`.

## Note (honest scope)
The DSP and sipm-optimization processors were rewritten as **one cohesive change**:
switching their raw input to `read_ldata` is inseparable from the output-layout change
(the loop now keys off `outdata["jldsp"]`). So those `read_ldata` switches live here,
not in the read-only PR.

## Dependencies
Writer-side counterpart to the LegendDataManagement path-resolver PR (which reads
`<tier>/<det>`). Independent of the other Juleana PRs.


## Since the first version
Resume check in `process_dsp_cal/phy`: with the `tier/<DetectorId>` layout the group keys
are Symbols; compare them as `String` so already-processed detectors are skipped again on
resume.
