### PR TITLE
processing: don't pre-create the empty ppars folder

### DIFF
--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -35,11 +35,9 @@ function det_sg_optimization(chinfo_det::NamedTuple)
 
         @info "Processing detector $det ($ch)"
 
-        mkpath(joinpath(data_path(l200.par.ppars.aoeopt), string(det)))
         pars_db_det = if isfile(joinpath(data_path(l200.par.ppars.aoeopt), "$det", "$part.yaml")) && !reprocess
             PropDict(l200.par.ppars.aoeopt[det, part])
         else
-            mkpath(joinpath(data_path(l200.par.ppars.aoeopt), "$det"))
             PropDict()
         end
 

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -33,11 +33,9 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         det = chinfo_det.detector
         part = chinfo_det.partition
 
-        mkpath(joinpath(data_path(l200.par.ppars.pz), string(det)))
         pars_db_det = if isfile(joinpath(data_path(l200.par.ppars.pz), "$det", "$part.yaml"))
             PropDict(l200.par.ppars.pz[det, part])
         else
-            mkpath(joinpath(data_path(l200.par.ppars.pz), "$det"))
             PropDict()
         end
 

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -35,11 +35,9 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
 
         @debug "Processing detector $det ($ch)"
         
-        mkpath(joinpath(data_path(l200.par.ppars.fltopt), string(det)))
         pars_db_det = if isfile(joinpath(data_path(l200.par.ppars.fltopt[det]), "$part.yaml"))
             PropDict(l200.par.ppars.fltopt[det, part])
         else
-            mkpath(joinpath(data_path(l200.par.ppars.fltopt), "$det"))
             PropDict()
         end
 


### PR DESCRIPTION
## What didn't work before
The processing setup pre-created the `ppars` output folder (with a validity entry)
*before* running a processor. When a processor failed, that left behind an empty
`ppars` folder marked valid.

## Why the change is necessary
`writelprops` already creates the folder when it writes results, so pre-creating it
is redundant — and the leftover empty-but-valid folders are misleading for failed
processors.

## What works now
The folder is no longer pre-created; it only appears when `writelprops` actually
writes output. Failed processors leave no stale `ppars` folder.