### PR TITLE
Add kwarg to event processor, enabling to skip veto systems

### DIFF
--- a/config/processing_config.yaml
+++ b/config/processing_config.yaml
@@ -188,7 +188,7 @@ processors:
     category: phy
     rank: 15
     kwargs:
-      include_vetoes: true
+      subsystems: [:geds, :spms, :pmts, :aux]
       reprocess: false
       timeout: 0
     dependencies:

--- a/config/processing_config.yaml
+++ b/config/processing_config.yaml
@@ -188,6 +188,7 @@ processors:
     category: phy
     rank: 15
     kwargs:
+      include_vetoes: true
       reprocess: false
       timeout: 0
     dependencies:

--- a/processors/process_evt_phy.jl
+++ b/processors/process_evt_phy.jl
@@ -1,4 +1,4 @@
-function process_evt_phy(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; include_vetoes::Bool=true, reprocess::Bool = false, timeout::Int=0)
+function process_evt_phy(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; subsystems::Vector{Symbol}=[:geds, :spms, :pmts, :aux], reprocess::Bool = false, timeout::Int=0)
     
     @info "Process events for period $period and run $run"
 
@@ -53,7 +53,7 @@ function process_evt_phy(processing_config::PropDict, l200::LegendData, period::
                         # generate evt level table
                         out_t, pmts_out_t = nothing, nothing
                         try 
-                            out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data, include_vetoes = false)
+                            out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data; subsystems)
                         catch e
                             @error "Error processing $fk: $(truncate_error(e))"
                             throw(ErrorException("Error processing $fk: $(truncate_error(e))"))
@@ -69,7 +69,7 @@ function process_evt_phy(processing_config::PropDict, l200::LegendData, period::
                             ds[:jlevt] = out_t
                         end
                         # write pmt evt file
-                        if !isempty(pmts_out_t) && include_vetoes
+                        if !isempty(pmts_out_t) && (:pmt in subsystems)
                             write_files(pmtevtfilename, use_cache = true, mode = CreateOrModify()) do pmtoutfilename
                                 # Remove cached PMT file if reprocess is enabled
                                 if reprocess && isfile(pmtoutfilename)

--- a/processors/process_evt_phy.jl
+++ b/processors/process_evt_phy.jl
@@ -1,4 +1,4 @@
-function process_evt_phy(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; reprocess::Bool = false, timeout::Int=0)
+function process_evt_phy(processing_config::PropDict, l200::LegendData, period::DataPeriod, run::DataRun,; include_vetoes::Bool=true, reprocess::Bool = false, timeout::Int=0)
     
     @info "Process events for period $period and run $run"
 
@@ -53,7 +53,7 @@ function process_evt_phy(processing_config::PropDict, l200::LegendData, period::
                         # generate evt level table
                         out_t, pmts_out_t = nothing, nothing
                         try 
-                            out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data)
+                            out_t, pmts_out_t = calibrate_all(l200, fk, dsp_data, include_vetoes = false)
                         catch e
                             @error "Error processing $fk: $(truncate_error(e))"
                             throw(ErrorException("Error processing $fk: $(truncate_error(e))"))
@@ -69,7 +69,7 @@ function process_evt_phy(processing_config::PropDict, l200::LegendData, period::
                             ds[:jlevt] = out_t
                         end
                         # write pmt evt file
-                        if !isempty(pmts_out_t)
+                        if !isempty(pmts_out_t) && include_vetoes
                             write_files(pmtevtfilename, use_cache = true, mode = CreateOrModify()) do pmtoutfilename
                                 # Remove cached PMT file if reprocess is enabled
                                 if reprocess && isfile(pmtoutfilename)


### PR DESCRIPTION
This PR adds the new `include_vetoes` kwarg introduced in https://github.com/legend-exp/LegendEventAnalysis.jl/pull/49 to the event tier processor and the processing config. 
This allows the user to choose whether the veto systems (PMTs and SiPMs) are also calibrated and included in the output event files.