### PR TITLE
Clear failure messages: physics guard in decay_time, upstream-pars preconditions, real causes in reports

### DIFF
--- a/processors/p_process_aoe_optimization.jl
+++ b/processors/p_process_aoe_optimization.jl
@@ -51,10 +51,19 @@ function det_sg_optimization(chinfo_det::NamedTuple)
 
         validity_det = get_partitionvalidity(l200, det, part)
 
+        # upstream preconditions: pz τ and the trap rt/ft from filter optimization for this det/partition
+        isfile(joinpath(data_path(l200.par.ppars.pz), "$det", "$part.yaml")) ||
+            throw(ErrorException("no partition pole-zero pars for $det ($part) — upstream p_process_decay_time failed or was skipped"))
         pars_tau = get_values(l200.par.ppars.pz[det, part])
+        haskey(pars_tau, det) ||
+            throw(ErrorException("no pole-zero τ for $det in $part pars — upstream p_process_decay_time failed or was skipped"))
         @debug "Loaded decay times"
 
+        isfile(joinpath(data_path(l200.par.ppars.fltopt[det]), "$part.yaml")) ||
+            throw(ErrorException("no partition filter-optimization pars for $det ($part) — upstream p_process_filter_optimization failed or was skipped"))
         pars_fltoptimization = get_values(l200.par.ppars.fltopt[det, part])
+        haskey(pars_fltoptimization, det) && haskey(pars_fltoptimization[det], :trap) ||
+            throw(ErrorException("no trap rt/ft pars for $det ($part) — upstream p_process_filter_optimization failed or was skipped"))
         @debug "Loaded energy optimization parameters"
 
         dsp_config_pd = dataprod_config(l200).dsp(filekey_det)

--- a/processors/p_process_decay_time.jl
+++ b/processors/p_process_decay_time.jl
@@ -125,6 +125,8 @@ function p_process_decay_time(processing_config::PropDict, l200::LegendData, per
         try
             cuts_τ = cut_single_peak(decay_times, min_τ, max_τ,; n_bins=nbins, relative_cut=rel_cut_fit)
             result, report = fit_single_trunc_gauss(decay_times, cuts_τ; uncertainty=true)
+            # physics guard: a fit escaping the search window has no usable τ peak
+            min_τ <= mvalue(result.μ) <= max_τ || throw(ErrorException("fitted τ = $(round(u"µs", mvalue(result.μ), digits=1)) outside ($min_τ, $max_τ) — no usable τ peak, consider a det-specific pz override or usability change"))
         catch e
             @error "Failed decay time extraction: $(truncate_error(e))"
             throw(ErrorException("Error in decay time extraction: $(truncate_error(e))"))

--- a/processors/p_process_filter_optimization.jl
+++ b/processors/p_process_filter_optimization.jl
@@ -51,7 +51,12 @@ function p_process_filter_optimization(processing_config::PropDict, l200::Legend
 
         validity_det = get_partitionvalidity(l200, det, part)
 
+        # upstream precondition: p_process_decay_time must have produced a τ for this det/partition
+        isfile(joinpath(data_path(l200.par.ppars.pz), "$det", "$part.yaml")) ||
+            throw(ErrorException("no partition pole-zero pars for $det ($part) — upstream p_process_decay_time failed or was skipped"))
         pars_tau = get_values(l200.par.ppars.pz[det, part])
+        haskey(pars_tau, det) ||
+            throw(ErrorException("no pole-zero τ for $det in $part pars — upstream p_process_decay_time failed or was skipped"))
         @debug "Loaded decay times"
 
         dsp_config_pd = dataprod_config(l200).dsp(filekey_det)

--- a/processors/process_aoe_optimization.jl
+++ b/processors/process_aoe_optimization.jl
@@ -112,6 +112,10 @@ function process_aoe_optimization(processing_config::PropDict, l200::LegendData,
 
                 aoe_config_flt = aoe_config_det.aoe_filter[filter_type]
 
+                # upstream preconditions: pz τ and the trap rt/ft from filter optimization
+                haskey(pars_tau, det) || throw(ErrorException("no pole-zero τ for $det — upstream decay_time failed or was skipped"))
+                haskey(pars_fltoptimization, det) && haskey(pars_fltoptimization[det], :trap) || throw(ErrorException("no trap rt/ft pars for $det — upstream filter_optimization failed or was skipped"))
+
                 dsp_sep, dsp_dep = nothing, nothing
                 try
                     # DSP

--- a/processors/process_decay_time.jl
+++ b/processors/process_decay_time.jl
@@ -112,6 +112,8 @@ function process_decay_time(processing_config::PropDict, l200::LegendData, perio
         try
             cuts_τ = cut_single_peak(decay_times, min_τ, max_τ,; n_bins=nbins, relative_cut=rel_cut_fit)
             result, report = fit_single_trunc_gauss(decay_times, cuts_τ)
+            # physics guard: a fit escaping the search window has no usable τ peak
+            min_τ <= mvalue(result.μ) <= max_τ || throw(ErrorException("fitted τ = $(round(u"µs", mvalue(result.μ), digits=1)) outside ($min_τ, $max_τ) — no usable τ peak, consider a det-specific pz override or usability change"))
         catch e
             @error "Failed decay time extraction: $(truncate_error(e))"
             throw(ErrorException("Error in decay time extraction: $(truncate_error(e))"))

--- a/processors/process_filter_optimization.jl
+++ b/processors/process_filter_optimization.jl
@@ -104,6 +104,9 @@ function process_filter_optimization(processing_config::PropDict, l200::LegendDa
         end
         yield()
 
+        # upstream precondition: decay_time must have produced a τ for this detector
+        haskey(pars_tau, det) || throw(ErrorException("no pole-zero τ for $det — upstream decay_time failed or was skipped"))
+
         # get QC cuts
         blmean_wdw = nothing
         try

--- a/src/log_texts.jl
+++ b/src/log_texts.jl
@@ -1,7 +1,9 @@
 # helper functions for logging
 function truncate_string(s::String, max_length::Int=1000)
     if length(s) > max_length
-        return s[1:max_length] * "..."
+        # `first` cuts after `max_length` characters, indexing would cut bytes and
+        # throw a `StringIndexError` in the middle of a multi-byte character like μ
+        return first(s, max_length) * "..."
     else
         return s
     end
@@ -20,7 +22,7 @@ function truncate_error(e::Exception, max_length::Int=1000)
     end
     s = string(@userfriendly_exceptions e)
     if length(s) > max_length
-        return s[1:max_length] * "..."
+        return first(s, max_length) * "..."
     else
         return s
     end

--- a/src/log_texts.jl
+++ b/src/log_texts.jl
@@ -8,8 +8,15 @@ function truncate_string(s::String, max_length::Int=1000)
 end
 
 function truncate_error(e::Exception, max_length::Int=1000)
-    if e isa CompositeException
-        e = e.exceptions[1]
+    # unwrap task/composite wrappers so reports show the actual cause, not "Task (failed) @0x..."
+    while true
+        if e isa TaskFailedException && e.task.exception isa Exception
+            e = e.task.exception
+        elseif e isa CompositeException && !isempty(e.exceptions)
+            e = e.exceptions[1]
+        else
+            break
+        end
     end
     s = string(@userfriendly_exceptions e)
     if length(s) > max_length


### PR DESCRIPTION
Four small changes so that a failure in a processing pass points at its cause:
- **decay_time (run + period):** a τ fit whose mean escapes the search window
  `(min_τ, max_τ)` is rejected with an explicit error (no usable τ peak — pz override or
  usability change) instead of writing a meaningless τ.
- **filter / A/E optimization (run + period):** check that the pole-zero τ and the trap
  rt/ft pars of the detector exist and say "upstream decay_time / filter_optimization
  failed or was skipped" — before, this surfaced as `MethodError`/`MissingProperty` deep
  inside the fit.
- **`truncate_error`:** unwrap `TaskFailedException` / `CompositeException` so reports show
  the actual exception, not `Task (failed) @0x…`.
- **`truncate_string`:** truncate by characters, not bytes (no `StringIndexError` on
  non-ASCII messages).
