### PR TITLE
lq_calibration_cut: derive the report filename from the processor name

### DIFF
--- a/processors/process_lq_calibration_cut.jl
+++ b/processors/process_lq_calibration_cut.jl
@@ -333,7 +333,9 @@ function process_lq_calibration_cut(processing_config::PropDict, l200::LegendDat
     lreport!(report, create_logtbl(result_lq))
 
     @info "Write log report"
-    writelreport(get_rreportfilename(l200, filekey, :lq), report)
+    # report name derived from the processor name like in every other processor
+    # (was hardcoded :lq, which check_report could not find)
+    writelreport(get_rreportfilename(l200, filekey, Symbol("$(last(split(string(nameof(var"#self#")), "process_")))")), report)
     @info report
 
     # flush stdout


### PR DESCRIPTION
The report was written under the hardcoded name `:lq` while every other processor derives
it from its own name; the report tooling (`check_report`) therefore never found it. Now
derived like everywhere else.
