### PR TITLE
p_process_skm_phy: filter jlevt file by file while reading 

### DIFF
--- a/processors/p_process_skm_phy.jl
+++ b/processors/p_process_skm_phy.jl
@@ -61,9 +61,9 @@ function p_process_skm_phy(processing_config::PropDict, l200::LegendData, period
                 # generate evt level table
                 out_t = nothing
                 try
-                    evt = read_ldata(l200, DataTier(:jlevt), filekeys)
                     skm_sel_pf = @pf !$aux.pulser.aux_trig && !$aux.forcedtrigger.aux_trig && $ged_pmt.is_valid_muon && $geds.is_valid_qc && $geds.is_valid_trig && $geds.is_valid_hit && $geds.multiplicity == 1 && $geds.max_e_cusp_ctc_cal > 500.0u"keV"
-                    out_t = evt[findall(skm_sel_pf.(evt))][:]
+                    # filter file by file while reading - a whole run's jlevt (up to ~35 GB) never sits in memory
+                    out_t = read_ldata(l200, DataTier(:jlevt), filekeys; filterby = skm_sel_pf)[:]
                 catch e
                     @error "Error processing $fk: $(truncate_error(e))"
                     throw(ErrorException("Error processing $fk: $(truncate_error(e))"))

--- a/processors/p_process_skm_phy.jl
+++ b/processors/p_process_skm_phy.jl
@@ -38,7 +38,7 @@ function p_process_skm_phy(processing_config::PropDict, l200::LegendData, period
         @info "Using output file: $(basename(skmfilename))"
         
         # start processing
-        global n_psd, n_lar, n_larpsd = 0, 0, 0
+        n_psd, n_lar, n_larpsd = 0, 0, 0
         write_files(skmfilename, use_cache = true, mode = CreateOrModify()) do outfilename
             if reprocess && isfile(outfilename)
                 @info "Reprocess $(basename(skmfilename)), remove old Evt."


### PR DESCRIPTION
- The processor read a run's whole jlevt tier into memory and filtered afterwards — up to
  ~35 GB per worker; with 32 workers per node this OOMed the jl-v0.7.0 production twice.
  Now `read_ldata(...; filterby = skm_sel_pf)` applies the skim selection per file before
  concatenation: measured peak 1.6 GB on the largest run (25 GB on disk), output verified
  identical to the old code (rows, all columns, LH5 layout).
- Drop a stray `global` on the survival-fraction counters (undefined on workers).
