### PR TITLE
interactive: check_report — summarize failures across the processing reports

### DIFF
--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -120,7 +120,7 @@ function execute_processors()
     process_steps, p_process_steps, additional_args = try
         steps_menu = MultiSelectMenu(String.(processing_config.possible_process_steps), ctrl_c_interrupt = true)
         p_steps_menu = MultiSelectMenu(String.(processing_config.p_possible_process_steps), ctrl_c_interrupt = true)
-        additional_args = ["reprocess", "no-reprocess", "check_dependencies"]
+        additional_args = ["reprocess", "no-reprocess", "check_dependencies", "check_report"]
         additional_args_menu = MultiSelectMenu(additional_args, ctrl_c_interrupt = true)
     
         # processing steps menu to select and deselect
@@ -147,6 +147,12 @@ function execute_processors()
         @warn "No processing steps selected"
         return
     else
+        # only inspect the reports of the selected steps and return without processing
+        if "check_report" in additional_args
+            check_reports(process_steps, p_process_steps)
+            return
+        end
+
         if "check_dependencies" in additional_args
             # set all process steps to true in case selection, false otherwise
             for p in processing_config.possible_process_steps
@@ -298,5 +304,136 @@ function execute_processors()
                 end
             end
         end
+    end
+end
+
+# read a report and return the number of result entries, the number of failed entries and
+# the failures as detector => error. An entry is a table row: per detector and filter type
+# for the fit reports, per filekey for the dsp reports - so for a dsp report the failure
+# count stays in filekeys while the labels name the individual failed detectors of each row.
+function get_report_failures(filename::AbstractString)
+    header, previous, n_entries, n_failed, failures = String[], String[], 0, 0, Tuple{String, String}[]
+    for line in eachline(filename)
+        # only markdown table rows are of interest
+        startswith(strip(line), "|") || continue
+        cells = strip.(split(strip(strip(line), '|'), "|"))
+        # a separator row marks the previous row as the header of a new table
+        if all(c -> !isempty(c) && all(in((':', '-')), c), cells)
+            header = previous
+            continue
+        end
+        previous = cells
+        # only tables with a status column hold results, the metadata table is skipped
+        i_status = findfirst(isequal("Status"), header)
+        (isnothing(i_status) || length(cells) != length(header)) && continue
+        n_entries += 1
+        occursin("Failure", replace(cells[i_status], r"<[^>]*>" => "")) || continue
+        n_failed += 1
+        # label the entry by detector, by the failed detectors of a dsp report or else by filekey
+        i_det = findfirst(in(("Detector", "Failed Detectors")), header)
+        labels = if isnothing(i_det) || cells[i_det] in ("", "-")
+            [first(cells)]
+        elseif header[i_det] == "Failed Detectors"
+            [m.captures[1] for m in eachmatch(r"\"([^\"]+)\"", cells[i_det])]
+        else
+            [cells[i_det]]
+        end
+        # add the filter/energy type and, for partition reports, the partition to
+        # distinguish several entries per detector; "-" cells carry no information
+        i_type = findfirst(in(("Filter Type", "Energy Type")), header)
+        i_part = findfirst(isequal("Partition"), header)
+        suffix = join([cells[i] for i in (i_type, i_part) if !isnothing(i) && !(cells[i] in ("", "-"))], ", ")
+        isempty(suffix) || (labels = labels .* " ($suffix)")
+        # collect every error-like column: the fit reports have "Error", the aoe/lq cut
+        # reports have "CalError" and "CutError" - matching on the substring covers all
+        i_errs = findall(h -> occursin("Error", h), header)
+        err = join([cells[i] for i in i_errs if !(cells[i] in ("", "-"))], " | ")
+        append!(failures, [(l, err) for l in labels])
+    end
+    return n_entries, n_failed, failures
+end
+
+# print all failed detectors in the reports of the selected process steps for the selected periods and runs
+function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Symbol})
+    # print one line per report and collect the failed detectors and their errors for the summary
+    function check_report(label::String, filename::AbstractString, failed::Dict{String, Vector{String}}, errors::Dict{String, Vector{String}})
+        if !isfile(filename)
+            printstyled("  $(rpad(label, 11)) no report\n"; color = :light_black)
+            return
+        end
+        n_entries, n_failed, failures = get_report_failures(filename)
+        if isempty(failures)
+            printstyled("  $(rpad(label, 11)) OK"; color = :green)
+            println(" ($n_entries entries)")
+            return
+        end
+        # collect run and error per detector, dropping the filter type suffix for the summary
+        for (det, err) in failures
+            push!(get!(failed, first(split(det, " (")), String[]), label)
+            isempty(err) || push!(get!(errors, first(split(det, " (")), String[]), err)
+        end
+        printstyled("  $(rpad(label, 11)) $n_failed of $n_entries entries failed: "; color = :red)
+        println(truncate_string(join(unique(first.(failures)), ", "), 80))
+    end
+
+    # print which detector failed in which runs and with which errors
+    function check_summary(process::Symbol, failed::Dict{String, Vector{String}}, errors::Dict{String, Vector{String}})
+        println("-"^110)
+        if isempty(failed)
+            printstyled("  All detectors passed in all checked reports of $(string(process))\n"; color = :green)
+        else
+            printstyled("  Summary $(string(process)): $(length(failed)) detector(s) with failures\n"; color = :red)
+            for det in sort(collect(keys(failed)))
+                runs_failed = unique(failed[det])
+                println("      $(rpad(det, 12)) $(lpad(length(runs_failed), 3)) run(s): $(truncate_string(join(runs_failed, ", "), 85))")
+                for err in unique(get(errors, det, String[]))
+                    println("      $(" "^12)      $(truncate_string(err, 100))")
+                end
+            end
+        end
+        println()
+    end
+
+    # reports written per run
+    for process in process_steps
+        report = Symbol("$(last(split(string(process), "process_")))")
+        category = processing_config.processors[process].category
+        printstyled("\n$(string(process)) ($category)\n"; bold = true)
+        println("-"^110)
+        failed, errors = Dict{String, Vector{String}}(), Dict{String, Vector{String}}()
+        for period in periods
+            for run in get_proccessable_runs(l200, period, runs)
+                filename = try
+                    get_rreportfilename(l200, start_filekey(l200, (period, run, category)), report)
+                catch e
+                    @warn "No start filekey for $period-$run-$category, skip"
+                    continue
+                end
+                check_report("$period-$run", filename, failed, errors)
+            end
+        end
+        check_summary(process, failed, errors)
+    end
+
+    # reports written per partition, i.e. one per period
+    for process in p_process_steps
+        report = Symbol("$(last(split(string(process), "process_")))")
+        # the cal-side partition processors carry no category key in the config (they
+        # hardcode :cal internally); only the phy ones declare it. A plain property access
+        # would yield a PropDicts.MissingProperty, which silently matches no filekey.
+        category = get(processing_config.p_processors[process], :category, "cal")
+        printstyled("\n$(string(process)) ($category)\n"; bold = true)
+        println("-"^110)
+        failed, errors = Dict{String, Vector{String}}(), Dict{String, Vector{String}}()
+        for period in periods
+            filename = try
+                get_preportfilename(l200, start_filekey(l200, (period, first(get_proccessable_runs(l200, period, runs)), category)), report)
+            catch e
+                @warn "No start filekey for $period-$category, skip"
+                continue
+            end
+            check_report("$period", filename, failed, errors)
+        end
+        check_summary(process, failed, errors)
     end
 end


### PR DESCRIPTION
New menu argument `check_report`: parses the run- and period-level reports of the selected
processors, periods and runs and prints per processor which detectors failed in which runs
with the (truncated) error message — instead of opening dozens of markdown reports by hand.
