### PR TITLE
interactive: rerun_failed — serial in-driver rerun of report failures with full exception chains

### DIFF
--- a/src/debug.jl
+++ b/src/debug.jl
@@ -1,0 +1,191 @@
+# Serial debug-rerun machinery for `rerun_failed` (see src/interactive.jl).
+# This file is included on the driver and on the workers (via @always_everywhere in
+# startup.jl): everything here is inert unless DEBUG_RERUN[] is set, and only
+# rerun_failed() on the driver ever sets it.
+
+# thrown by the serial parallel() branch after diagnosing the matched items so the
+# processor aborts before it can write pars/plots/reports built from filtered results
+struct DebugAbort <: Exception
+    process::Symbol
+    n_matched::Int
+end
+
+# one full exception chain, captured while the error was still being handled
+struct DebugCapture
+    item::Any               # iterator item being processed, nothing outside parallel
+    when::DateTime
+    stack::Base.ExceptionStack
+end
+
+mutable struct DebugRerunState
+    process::Symbol
+    detectors::Set{String}                  # failed detectors from the reports
+    partitions::Dict{String, Set{String}}   # detector => partitions; absent/empty = all
+    io::IO                                  # verbose log sink, written through per capture
+    task::Task                              # only capture exceptions raised in this task
+    current_item::Any
+    captures::Vector{DebugCapture}
+    failed_rows::Vector{Any}                # ProcessStatus(0) rows returned by the closures
+    matched_any::Bool
+end
+DebugRerunState(process::Symbol, detectors::Set{String}, partitions::Dict{String, Set{String}}, io::IO) =
+    DebugRerunState(process, detectors, partitions, io, current_task(), nothing, DebugCapture[], Any[], false)
+
+const DEBUG_RERUN = Ref{Union{Nothing, DebugRerunState}}(nothing)
+
+# a zero-match stage this small is executed for real instead of skipped: auxiliary
+# stages like the pulser stage of process_hit_cal produce files the main stage reads
+const DEBUG_PASSTHROUGH_MAX_ITEMS = 2
+
+_debug_label(itr) = itr isa NamedTuple && haskey(itr, :detector) ?
+    string(itr.detector) * (haskey(itr, :partition) ? " ($(itr.partition))" : "") : string(itr)
+_debug_label(::Nothing) = "processor level (outside parallel)"
+
+function _debug_matches(st::DebugRerunState, itr)
+    itr isa NamedTuple && haskey(itr, :detector) || return false
+    det = string(itr.detector)
+    det in st.detectors || return false
+    haskey(itr, :partition) || return true
+    parts = get(st.partitions, det, nothing)
+    return isnothing(parts) || isempty(parts) || string(itr.partition) in parts
+end
+
+# called from truncate_error, i.e. from inside the catch blocks of the processors,
+# where Base.current_exceptions() still holds the original exception and backtrace
+# underneath any rethrown wrapper. Must stay a cheap no-op when inactive.
+function _debug_capture()
+    st = DEBUG_RERUN[]
+    isnothing(st) && return nothing
+    current_task() === st.task || return nothing
+    stack = Base.current_exceptions()
+    isempty(stack) && return nothing
+    push!(st.captures, DebugCapture(st.current_item, Dates.now(), stack))
+    _write_capture(st.io, last(st.captures), length(st.captures))
+    return nothing
+end
+
+# the chain is ordered oldest to most recent: entry [1] is the root cause, the last
+# entry is the wrapper text that ends up in the report
+function _write_capture(io::IO, cap::DebugCapture, n::Int)
+    println(io, "\n", "="^100)
+    println(io, "## capture $n at $(cap.when) — item: $(_debug_label(cap.item)) — exception chain of length $(length(cap.stack))")
+    for (i, entry) in enumerate(cap.stack)
+        println(io, "\n-- exception [$i]", i == 1 ? " (root cause)" : " (wrapped around the previous one)")
+        showerror(io, entry.exception)
+        println(io)
+        Base.show_backtrace(IOContext(io, :color => false, :limit => true, :displaysize => (24, 240)), entry.backtrace)
+        println(io)
+    end
+    flush(io)
+end
+
+# innermost exception plus the first frame in LEGEND/Juleana code, for the REPL summary
+function _root_cause(stack::Base.ExceptionStack)
+    isempty(stack) && return nothing, nothing
+    root = first(stack)
+    frames = Base.stacktrace(root.backtrace)
+    isempty(frames) && return root.exception, nothing
+    # never point at the debug machinery itself, it is part of every serial backtrace
+    i = findfirst(fr -> occursin(r"Legend|Juleana|processors", string(fr.file)) && !endswith(string(fr.file), joinpath("src", "debug.jl")), frames)
+    # fall back to the first frame outside base julia (base files print as ./file.jl or
+    # live under share/julia), then to the innermost frame
+    if isnothing(i)
+        i = findfirst(fr -> !startswith(string(fr.file), "./") && !occursin("share/julia", string(fr.file)) && !endswith(string(fr.file), joinpath("src", "debug.jl")), frames)
+    end
+    return root.exception, frames[isnothing(i) ? 1 : i]
+end
+
+# best capture per item: several fire per failure (inner @error, outer catch), the
+# longest chain carries the most context
+function _best_captures(st::DebugRerunState)
+    best = Dict{Any, DebugCapture}()
+    for c in st.captures
+        b = get(best, c.item, nothing)
+        if isnothing(b) || length(c.stack) > length(b.stack)
+            best[c.item] = c
+        end
+    end
+    return best
+end
+
+# replica of the worker catch in parallel() so pass-through stages return the same
+# log rows the report writer expects
+function _debug_error_log_row(log_nt::UnionAll, itr, e)
+    if e isa TaskFailedException
+        e = e.task.exception
+    end
+    if itr isa NamedTuple && haskey(itr, :channel) && haskey(itr, :detector)
+        if haskey(itr, :partition)
+            return log_nt((itr.detector, itr.channel, itr.partition, ProcessStatus(0), fill("-", length(fieldnames(log_nt))-5)..., "$(truncate_string(string(e)))"))
+        else
+            return log_nt((itr.detector, itr.channel, ProcessStatus(0), fill("-", length(fieldnames(log_nt))-4)..., "$(truncate_string(string(e)))"))
+        end
+    elseif itr isa FileKey
+        return log_nt((itr, ProcessStatus(0), fill("-", length(fieldnames(log_nt))-3)..., "$(truncate_string(string(e)))"))
+    else
+        throw(ErrorException("No logging for $(itr)"))
+    end
+end
+
+# collect the failed rows a closure returned without throwing (most closures catch
+# per stage and only mark the log row) so the summary can cross-check the captures
+function _debug_collect_failed_rows!(st::DebugRerunState, itr, res)
+    res isa NamedTuple && haskey(res, :log) || return nothing
+    rows = res.log isa AbstractDict ? collect(values(res.log)) : [res.log]
+    for row in rows
+        if row isa NamedTuple && haskey(row, :Status) && row.Status == ProcessStatus(0)
+            push!(st.failed_rows, (item = itr, row = row))
+        end
+    end
+    return nothing
+end
+
+# serial replacement for the worker dispatch in parallel(): run the matched items in
+# the driver task itself so the truncate_error hook sees the full exception chains
+function debug_serial_parallel(st::DebugRerunState, iterator::AbstractArray, f::Function, log_nt::UnionAll; process_name::String="")
+    sel = [itr for itr in iterator if _debug_matches(st, itr)]
+    if isempty(sel)
+        if length(iterator) <= DEBUG_PASSTHROUGH_MAX_ITEMS
+            @info "[debug rerun] $process_name: no matching item, running the $(length(iterator))-item auxiliary stage for real"
+            println(st.io, "\n# stage $process_name: no matching items, ran all $(length(iterator)) item(s) for real (auxiliary stage)")
+            flush(st.io)
+            return map(collect(iterator)) do itr
+                st.current_item = itr
+                try
+                    itr => f(itr)
+                catch e
+                    push!(st.captures, DebugCapture(itr, Dates.now(), Base.current_exceptions()))
+                    _write_capture(st.io, last(st.captures), length(st.captures))
+                    itr => (processed = false, log = _debug_error_log_row(log_nt, itr, e))
+                finally
+                    st.current_item = nothing
+                end
+            end
+        end
+        @info "[debug rerun] $process_name: 0 of $(length(iterator)) items match — passing this stage through empty"
+        println(st.io, "\n# stage $process_name: no matching items ($(length(iterator)) total) — passed through empty")
+        flush(st.io)
+        return Pair[]
+    end
+    st.matched_any = true
+    println(st.io, "\n# stage $process_name: running $(length(sel)) matched item(s) serially in the driver")
+    flush(st.io)
+    for (i, itr) in enumerate(sel)
+        label = _debug_label(itr)
+        @info "[debug rerun] ($i/$(length(sel))) $label — serial run for full logs and exception chains"
+        st.current_item = itr
+        t_start = time()
+        try
+            _debug_collect_failed_rows!(st, itr, f(itr))
+        catch e
+            # the closure let the exception escape: capture the chain here instead
+            push!(st.captures, DebugCapture(itr, Dates.now(), Base.current_exceptions()))
+            _write_capture(st.io, last(st.captures), length(st.captures))
+        finally
+            st.current_item = nothing
+        end
+        @info "[debug rerun] $label finished in $(round(time() - t_start, digits=1)) s"
+    end
+    # diagnosis done: abort the processor before it writes pars/reports from filtered results
+    throw(DebugAbort(st.process, length(sel)))
+end

--- a/src/interactive.jl
+++ b/src/interactive.jl
@@ -120,7 +120,7 @@ function execute_processors()
     process_steps, p_process_steps, additional_args = try
         steps_menu = MultiSelectMenu(String.(processing_config.possible_process_steps), ctrl_c_interrupt = true)
         p_steps_menu = MultiSelectMenu(String.(processing_config.p_possible_process_steps), ctrl_c_interrupt = true)
-        additional_args = ["reprocess", "no-reprocess", "check_dependencies", "check_report"]
+        additional_args = ["reprocess", "no-reprocess", "check_dependencies", "check_report", "rerun_failed"]
         additional_args_menu = MultiSelectMenu(additional_args, ctrl_c_interrupt = true)
     
         # processing steps menu to select and deselect
@@ -147,9 +147,13 @@ function execute_processors()
         @warn "No processing steps selected"
         return
     else
-        # only inspect the reports of the selected steps and return without processing
-        if "check_report" in additional_args
-            check_reports(process_steps, p_process_steps)
+        # only inspect the reports of the selected steps and return without processing;
+        # rerun_failed additionally reruns the failed detectors serially for diagnosis
+        if "check_report" in additional_args || "rerun_failed" in additional_args
+            failures = check_reports(process_steps, p_process_steps)
+            if "rerun_failed" in additional_args
+                rerun_failed(failures)
+            end
             return
         end
 
@@ -308,11 +312,13 @@ function execute_processors()
 end
 
 # read a report and return the number of result entries, the number of failed entries and
-# the failures as detector => error. An entry is a table row: per detector and filter type
-# for the fit reports, per filekey for the dsp reports - so for a dsp report the failure
-# count stays in filekeys while the labels name the individual failed detectors of each row.
+# the failures with detector, filter type, partition, error text and a printable label.
+# An entry is a table row: per detector and filter type for the fit reports, per filekey
+# for the dsp reports - so for a dsp report the failure count stays in filekeys while
+# the labels name the individual failed detectors of each row.
 function get_report_failures(filename::AbstractString)
-    header, previous, n_entries, n_failed, failures = String[], String[], 0, 0, Tuple{String, String}[]
+    failures = @NamedTuple{detector::String, filter_type::Union{Nothing, String}, partition::Union{Nothing, String}, error::String, label::String}[]
+    header, previous, n_entries, n_failed = String[], String[], 0, 0
     for line in eachline(filename)
         # only markdown table rows are of interest
         startswith(strip(line), "|") || continue
@@ -338,25 +344,54 @@ function get_report_failures(filename::AbstractString)
         else
             [cells[i_det]]
         end
-        # add the filter/energy type and, for partition reports, the partition to
+        # keep the filter/energy type and, for partition reports, the partition to
         # distinguish several entries per detector; "-" cells carry no information
         i_type = findfirst(in(("Filter Type", "Energy Type")), header)
         i_part = findfirst(isequal("Partition"), header)
-        suffix = join([cells[i] for i in (i_type, i_part) if !isnothing(i) && !(cells[i] in ("", "-"))], ", ")
-        isempty(suffix) || (labels = labels .* " ($suffix)")
+        ftype = (isnothing(i_type) || cells[i_type] in ("", "-")) ? nothing : String(cells[i_type])
+        part = (isnothing(i_part) || cells[i_part] in ("", "-")) ? nothing : String(cells[i_part])
+        suffix = join([s for s in (ftype, part) if !isnothing(s)], ", ")
         # collect every error-like column: the fit reports have "Error", the aoe/lq cut
         # reports have "CalError" and "CutError" - matching on the substring covers all
         i_errs = findall(h -> occursin("Error", h), header)
         err = join([cells[i] for i in i_errs if !(cells[i] in ("", "-"))], " | ")
-        append!(failures, [(l, err) for l in labels])
+        append!(failures, [(detector = String(l), filter_type = ftype, partition = part, error = err,
+                            label = isempty(suffix) ? String(l) : "$l ($suffix)") for l in labels])
     end
     return n_entries, n_failed, failures
 end
 
-# print all failed detectors in the reports of the selected process steps for the selected periods and runs
+# a single failed report entry with everything needed to rerun it for diagnosis
+struct ReportFailure
+    process::Symbol
+    level::Symbol                     # :run or :partition
+    category::Union{String, Symbol}
+    period::DataPeriod
+    run::Union{DataRun, Nothing}      # nothing for partition-level reports
+    detector::String
+    filter_type::Union{Nothing, String}
+    partition::Union{Nothing, String}
+    error::String
+end
+
+# report filename of a processor for a period/run, as derived by the processor itself
+function report_filename(process::Symbol, level::Symbol, category, period::DataPeriod, run::Union{DataRun, Nothing})
+    report = Symbol("$(last(split(string(process), "process_")))")
+    if level == :run
+        return get_rreportfilename(l200, start_filekey(l200, (period, run, category)), report)
+    else
+        return get_preportfilename(l200, start_filekey(l200, (period, first(get_proccessable_runs(l200, period, runs)), category)), report)
+    end
+end
+
+# print all failed detectors in the reports of the selected process steps for the selected
+# periods and runs; returns all failures as ReportFailure records for rerun_failed
 function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Symbol})
+    all_failures = ReportFailure[]
+
     # print one line per report and collect the failed detectors and their errors for the summary
-    function check_report(label::String, filename::AbstractString, failed::Dict{String, Vector{String}}, errors::Dict{String, Vector{String}})
+    function check_report(label::String, filename::AbstractString, failed::Dict{String, Vector{String}}, errors::Dict{String, Vector{String}},
+                          process::Symbol, level::Symbol, category, period::DataPeriod, run::Union{DataRun, Nothing})
         if !isfile(filename)
             printstyled("  $(rpad(label, 11)) no report\n"; color = :light_black)
             return
@@ -367,13 +402,14 @@ function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Sy
             println(" ($n_entries entries)")
             return
         end
-        # collect run and error per detector, dropping the filter type suffix for the summary
-        for (det, err) in failures
-            push!(get!(failed, first(split(det, " (")), String[]), label)
-            isempty(err) || push!(get!(errors, first(split(det, " (")), String[]), err)
+        # collect run and error per detector for the summary plus the full failure records
+        for fl in failures
+            push!(all_failures, ReportFailure(process, level, category, period, run, fl.detector, fl.filter_type, fl.partition, fl.error))
+            push!(get!(failed, fl.detector, String[]), label)
+            isempty(fl.error) || push!(get!(errors, fl.detector, String[]), fl.error)
         end
         printstyled("  $(rpad(label, 11)) $n_failed of $n_entries entries failed: "; color = :red)
-        println(truncate_string(join(unique(first.(failures)), ", "), 80))
+        println(truncate_string(join(unique([fl.label for fl in failures]), ", "), 80))
     end
 
     # print which detector failed in which runs and with which errors
@@ -396,7 +432,6 @@ function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Sy
 
     # reports written per run
     for process in process_steps
-        report = Symbol("$(last(split(string(process), "process_")))")
         category = processing_config.processors[process].category
         printstyled("\n$(string(process)) ($category)\n"; bold = true)
         println("-"^110)
@@ -404,12 +439,12 @@ function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Sy
         for period in periods
             for run in get_proccessable_runs(l200, period, runs)
                 filename = try
-                    get_rreportfilename(l200, start_filekey(l200, (period, run, category)), report)
+                    report_filename(process, :run, category, period, run)
                 catch e
                     @warn "No start filekey for $period-$run-$category, skip"
                     continue
                 end
-                check_report("$period-$run", filename, failed, errors)
+                check_report("$period-$run", filename, failed, errors, process, :run, category, period, run)
             end
         end
         check_summary(process, failed, errors)
@@ -417,7 +452,6 @@ function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Sy
 
     # reports written per partition, i.e. one per period
     for process in p_process_steps
-        report = Symbol("$(last(split(string(process), "process_")))")
         # the cal-side partition processors carry no category key in the config (they
         # hardcode :cal internally); only the phy ones declare it. A plain property access
         # would yield a PropDicts.MissingProperty, which silently matches no filekey.
@@ -427,13 +461,165 @@ function check_reports(process_steps::Vector{Symbol}, p_process_steps::Vector{Sy
         failed, errors = Dict{String, Vector{String}}(), Dict{String, Vector{String}}()
         for period in periods
             filename = try
-                get_preportfilename(l200, start_filekey(l200, (period, first(get_proccessable_runs(l200, period, runs)), category)), report)
+                report_filename(process, :partition, category, period, nothing)
             catch e
                 @warn "No start filekey for $period-$category, skip"
                 continue
             end
-            check_report("$period", filename, failed, errors)
+            check_report("$period", filename, failed, errors, process, :partition, category, period, nothing)
         end
         check_summary(process, failed, errors)
     end
+
+    return all_failures
+end
+# processors whose parallel iterator is FileKey-based: their per-detector loop runs
+# inside the worker closure, so a detector filter cannot be applied from the outside.
+# peak_split is also excluded because its filekey pre-stage rewrites the keylist.
+const DEBUG_RERUN_EXCLUDED = Set([:process_dsp_cal, :process_dsp_phy, :process_evt_phy, :process_peak_split, :p_process_skm_phy])
+
+# rerun the report failures serially in the driver with full error logs. Diagnosis only:
+# the processor is aborted before it can write pars/reports (see src/debug.jl); fixing
+# a failure stays a normal processor run with reprocess=false afterwards.
+function rerun_failed(failures::Vector{ReportFailure})
+    if isempty(failures)
+        @info "No failures found in the checked reports - nothing to rerun"
+        return
+    end
+    excluded = filter(f -> f.process in DEBUG_RERUN_EXCLUDED, failures)
+    todo = filter(f -> !(f.process in DEBUG_RERUN_EXCLUDED), failures)
+
+    printstyled("\nDebug rerun of failed detectors\n"; bold = true)
+    println("-"^110)
+    if !isempty(excluded)
+        printstyled("  Not auto-rerunnable (filekey-level processors), use the manual workflow:\n"; color = :yellow)
+        excluded_groups = Dict{Tuple{Symbol, DataPeriod, Union{DataRun, Nothing}}, Vector{String}}()
+        for f in excluded
+            push!(get!(excluded_groups, (f.process, f.period, f.run), String[]), f.detector)
+        end
+        for k in sort(collect(keys(excluded_groups)); by = k -> (string(k[1]), string(k[2]), isnothing(k[3]) ? "" : string(k[3])))
+            println("      $(k[1]) $(k[2])$(isnothing(k[3]) ? "" : "-$(k[3])"): $(truncate_string(join(unique(excluded_groups[k]), ", "), 80))")
+        end
+    end
+
+    # group the rerunnable failures by processor and period/run
+    groups = Dict{Tuple{Symbol, Symbol, Any, DataPeriod, Union{DataRun, Nothing}}, Vector{ReportFailure}}()
+    for f in todo
+        push!(get!(groups, (f.process, f.level, f.category, f.period, f.run), ReportFailure[]), f)
+    end
+    group_keys = sort(collect(keys(groups)); by = k -> (k[2] == :partition, string(k[1]), string(k[4]), isnothing(k[5]) ? "" : string(k[5])))
+    if isempty(group_keys)
+        @info "No auto-rerunnable failures"
+        return
+    end
+
+    # select the groups to rerun, all preselected
+    options = ["$(k[1]) $(k[4])$(isnothing(k[5]) ? "" : "-$(k[5])") - $(length(groups[k])) failure(s): $(truncate_string(join(unique([f.detector for f in groups[k]]), ", "), 60))" for k in group_keys]
+    selected = try
+        menu = MultiSelectMenu(options; ctrl_c_interrupt = true, pagesize = min(length(options), 15), selected = 1:length(options))
+        sort(collect(request("Select failure groups for the serial debug rerun:", menu)))
+    catch e
+        println()
+        @error "Abort: $e"
+        return
+    end
+    if isempty(selected)
+        @warn "No groups selected"
+        return
+    end
+    println()
+    @info "Reruns execute the real per-detector code serially in this session: control plots of the rerun detectors are rewritten (from unchanged inputs), pars and reports are protected by an abort before their write stage."
+    for i in selected
+        k = group_keys[i]
+        debug_rerun_group(k..., groups[k])
+    end
+end
+
+# rerun one (processor, period[, run]) group of failures serially and summarize
+function debug_rerun_group(process::Symbol, level::Symbol, category, period::DataPeriod, run::Union{DataRun, Nothing}, fls::Vector{ReportFailure})
+    dets = Set{String}(f.detector for f in fls)
+    partitions = Dict{String, Set{String}}()
+    for f in fls
+        isnothing(f.partition) || push!(get!(partitions, f.detector, Set{String}()), f.partition)
+    end
+
+    logdir = mkpath(joinpath(processing_config.processing.log_path, "debug_rerun"))
+    logfile = joinpath(logdir, "$(process)_$(period)$(isnothing(run) ? "" : "-$(run)")_$(Dates.format(Dates.now(), "yyyy-mm-dd-HHMMSS")).log")
+    printstyled("\n== debug rerun $(process) $(period)$(isnothing(run) ? "" : "-$(run)") - $(length(dets)) detector(s)\n"; bold = true)
+
+    open(logfile, "w") do io
+        println(io, "# Juleana debug rerun - $process $period $(isnothing(run) ? "(partition level)" : run) - $(Dates.now())")
+        println(io, "# Failures from the report:")
+        for f in fls
+            suffix = join([s for s in (f.filter_type, f.partition) if !isnothing(s)], ", ")
+            println(io, "#   $(f.detector)$(isempty(suffix) ? "" : " ($suffix)"): $(f.error)")
+        end
+        flush(io)
+
+        st = DebugRerunState(process, dets, partitions, io)
+        report_file = try report_filename(process, level, category, period, run) catch e "" end
+        report_before = !isempty(report_file) && isfile(report_file) ? read(report_file) : nothing
+
+        # take the configured kwargs like execute_processors, then force the diagnosis
+        # settings every processor understands (failed entries have no pars, so
+        # reprocess=false recomputes exactly them; timeout is ignored serially anyway)
+        cfg = level == :run ? processing_config.processors[process] : processing_config.p_processors[process]
+        kwargs = NamedTuple([(k, v) for (k, v) in pairs(cfg.kwargs)])
+        func = getfield(Main, process)
+        sig = level == :run ? Tuple{PropDict, LegendData, DataPeriod, DataRun} : Tuple{PropDict, LegendData, DataPeriod}
+        for (k, v) in pairs((reprocess = false, timeout = 0, only_first_period = false))
+            if hasmethod(func, sig, (k,))
+                kwargs = merge(kwargs, NamedTuple((k => v,)))
+            end
+        end
+
+        DEBUG_RERUN[] = st
+        try
+            if level == :run
+                func(processing_config, l200, period, run; kwargs...)
+            else
+                func(processing_config, l200, period; kwargs...)
+            end
+            @warn "$(process) completed without matching any parallel stage - no detector was diagnosed (label mismatch?)"
+        catch e
+            if e isa DebugAbort
+                @info "Aborted $(process) after the diagnosed stage, before any pars/report writes (as intended)"
+            else
+                # processor-level failure before/outside parallel; truncate_error also
+                # snapshots the full chain into the log via the debug hook
+                @error "Processor-level failure outside the parallel stages: $(truncate_error(e isa Exception ? e : ErrorException(string(e))))"
+            end
+        finally
+            DEBUG_RERUN[] = nothing
+            # report guard: undo an accidental rewrite (only reachable without the abort)
+            if !isnothing(report_before) && isfile(report_file) && read(report_file) != report_before
+                write(report_file, report_before)
+                @warn "Report $(basename(report_file)) was modified by the debug rerun - original content restored"
+            end
+        end
+        print_debug_summary(st, logfile)
+    end
+end
+
+# compact per-detector summary: root cause, code location and the report wrapper text
+function print_debug_summary(st::DebugRerunState, logfile::AbstractString)
+    println("-"^110)
+    best = _best_captures(st)
+    for (item, cap) in sort(collect(best); by = p -> _debug_label(p[1]))
+        exc, frame = _root_cause(cap.stack)
+        println("  $(rpad(_debug_label(item), 28)) $(truncate_string(isnothing(exc) ? "?" : sprint(showerror, exc), 90))")
+        wrapper = length(cap.stack) > 1 ? "  [report text: $(truncate_string(string(last(cap.stack).exception), 60))]" : ""
+        isnothing(frame) || println("  $(" "^28) at $(frame.file):$(frame.line)$wrapper")
+    end
+    # failed log rows the closures returned without any captured exception chain
+    captured_items = Set(keys(best))
+    for fr in st.failed_rows
+        fr.item in captured_items && continue
+        err = haskey(fr.row, :Error) ? string(fr.row.Error) : "-"
+        println("  $(rpad(_debug_label(fr.item), 28)) no exception chain captured - closure log text: $(truncate_string(err, 80))")
+    end
+    if isempty(st.captures) && isempty(st.failed_rows)
+        printstyled("  nothing matched or nothing failed - nothing diagnosed\n"; color = :yellow)
+    end
+    println("  full exception chains with backtraces: $logfile")
 end

--- a/src/log_texts.jl
+++ b/src/log_texts.jl
@@ -8,6 +8,9 @@ function truncate_string(s::String, max_length::Int=1000)
 end
 
 function truncate_error(e::Exception, max_length::Int=1000)
+    # debug rerun: snapshot the full exception chain while it is still live, since
+    # every per-stage catch in the processors goes through here (no-op otherwise)
+    _debug_capture()
     if e isa CompositeException
         e = e.exceptions[1]
     end

--- a/src/parallel.jl
+++ b/src/parallel.jl
@@ -52,6 +52,13 @@ function retry_check(delay_state, err)
 end
 
 function parallel(iterator::AbstractArray, f::Function, log_nt::UnionAll, wpool::WorkerPool; timeout::Int=0, retry::Bool=false, process_name::String="")
+    # debug rerun (see src/debug.jl): run the matching items serially in the driver
+    # task for full exception chains, never dispatch to workers; timeout and retry
+    # do not apply there
+    if !isnothing(DEBUG_RERUN[])
+        return debug_serial_parallel(DEBUG_RERUN[], iterator, f, log_nt; process_name=process_name)
+    end
+
     # prevent crash from Base
     Base.exit_on_sigint(false)
 

--- a/src/startup.jl
+++ b/src/startup.jl
@@ -30,6 +30,7 @@ using ParallelProcessingTools: getlabel
     using ArgParse
 
     global_logger(TerminalLogger())
+    include(joinpath(@__DIR__,"debug.jl"))
     include(joinpath(@__DIR__,"log_texts.jl"))
 
     # free memory


### PR DESCRIPTION
Debug mode on top of `check_report`: `rerun_failed` lets you pick a (processor, period, run)
group of failures and reruns exactly those detectors serially in the driver (no workers,
no timeout/retry). Every per-stage `catch` in the processors goes through `truncate_error`,
which in this mode snapshots the live exception chain, so the output shows the real root
cause with the full stack instead of the truncated one-line report entry. Off unless
requested; `parallel()` only checks a flag.
