### PR TITLE
sipm calibration: persist the SiPM noise threshold per detector in the pars

### DIFF
--- a/processors/p_process_sipm_calibration_phy.jl
+++ b/processors/p_process_sipm_calibration_phy.jl
@@ -210,6 +210,8 @@ function p_process_sipm_calibration_phy(processing_config::PropDict, l200::Legen
                 result_energy = (
                     m_cal_simple = result_simple.c,
                     n_cal_simple = result_simple.offset,
+                    noise_threshold = result_simple.noise_threshold,
+                    noise_threshold_cal = result_simple.noise_threshold_cal,
                     cal = result_calib,
                     fit  = result_fit,
                 )

--- a/processors/process_sipm_calibration_phy.jl
+++ b/processors/process_sipm_calibration_phy.jl
@@ -178,6 +178,8 @@ function process_sipm_calibration_phy(processing_config::PropDict, l200::LegendD
                 result_energy = (
                     m_cal_simple = result_simple.c,
                     n_cal_simple = result_simple.offset,
+                    noise_threshold = result_simple.noise_threshold,
+                    noise_threshold_cal = result_simple.noise_threshold_cal,
                     cal = result_calib,
                     fit  = result_fit,
                 )


### PR DESCRIPTION
## What
`process_sipm_calibration_phy` and `p_process_sipm_calibration_phy` store the noise/1PE
threshold that `sipm_simple_calibration` actually used — `noise_threshold` (ADC) and
`noise_threshold_cal` (P.E.) — per detector in the SiPM calibration pars, next to the
calibration constants.

## Why
The threshold is detected per channel (valley after the noise peak); without persisting it,
downstream steps and reports cannot reproduce which triggers were counted as signal.

## Depends on
LegendSpecFits sipm-simple-cal (legend-exp/LegendSpecFits.jl#194): adds `noise_threshold` /
`noise_threshold_cal` to the `sipm_simple_calibration` result. Rebased onto current main.
